### PR TITLE
Add multi-arg functions via list destructing of arguments

### DIFF
--- a/evaluate.ts
+++ b/evaluate.ts
@@ -142,15 +142,33 @@ export function parse(source: string, filename = "script"): PSLiteral<PSValue> {
 }
 
 export function concat(parent: PSMap, child: PSMap): PSMap {
-  let properties = Object.keys(child.value).reduce((props, key) => {
-    return Object.assign(props, {
-      [key]: {
-        enumerable: true,
-        configurable: true,
-        get: () => child.value[key],
-      } as PropertyDescriptor,
-    });
-  }, {});
+  let properties = {};
+  Object.assign(
+    properties,
+    Object.keys(parent.value).reduce((props, key) => {
+      return Object.assign(props, {
+        [key]: {
+          enumerable: true,
+          configurable: true,
+          get: () => parent.value[key],
+        } as PropertyDescriptor,
+      });
+    }, {}),
+  );
+
+  Object.assign(
+    properties,
+    Object.keys(child.value).reduce((props, key) => {
+      return Object.assign(props, {
+        [key]: {
+          enumerable: true,
+          configurable: true,
+          get: () => child.value[key],
+        } as PropertyDescriptor,
+      });
+    }, {}),
+  );
+
   return {
     type: "map",
     value: Object.create(parent.value, properties),

--- a/test/fn.test.ts
+++ b/test/fn.test.ts
@@ -1,0 +1,75 @@
+import type { PSMap } from "../mod.ts";
+import { describe, expect, it } from "./suite.ts";
+import { evaluate } from "../mod.ts";
+
+describe("Fn", () => {
+  it("can destructure list arguments", async () => {
+    expect(
+      await evaluate(
+        `
+let:
+  add(x,y): {+: [x,y] }
+do: { add: [2,40] }
+`,
+        {
+          context: math,
+        },
+      ),
+    ).toEqual({ type: "number", value: 42 });
+  });
+  it("throws an error if destructured args are not a list", async () => {
+    try {
+      await evaluate(`
+let:
+  pair(x,y): [x,y]
+do: { pair: 5 }
+`);
+      throw new Error(`expected to throw an error, but did not`);
+    } catch (error) {
+      expect(error.message).toMatch(/must be a list/i);
+    }
+  });
+  it("throws an error if an argument list is not long enough to satisfy the destructuring", async () => {
+    try {
+      await evaluate(`
+let:
+  triplet(x,y,z): [x,y,z]
+do: { triplet: [1,2] }
+`);
+      throw new Error(`expected an error, but did not receive one`);
+    } catch (error) {
+      expect(error.message).toMatch(/must have at least 3 elements/);
+    }
+  });
+  it("can have no arguments", async () => {
+    let result = await evaluate(`
+let:
+  thunk(): "this is it"
+do: { thunk: true }
+`);
+    expect(result.type).toEqual("string");
+    //@ts-expect-error value is not on all psvalue.
+    expect(result.value).toEqual("this is it");
+  });
+});
+
+const math: PSMap = {
+  type: "map",
+  value: {
+    "+": {
+      type: "fn",
+      *value({ arg, env }) {
+        let sum = 0;
+        if (arg.type === "list") {
+          for (let item of arg.value) {
+            let element = yield* env.eval(item);
+            if (element.type === "number") {
+              sum += element.value;
+            }
+          }
+        }
+        return { type: "number", value: sum };
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Motivation
Sometimes it makes sense to be able to define a function with multiple arguments like:

```yaml
add(x,y): {+: [x,y]}
```

However, PlatformScript functions only take a single argument.

## Approach
We don't change this fundamental dynamic. If you want to call a function that needs multiple values, pass it a list. What we do provide is a syntax for destructuring arguments so that you can capture mulitple values from a list inside a function.