### PR TITLE
Use `$` sigil for all references, including inside strings

### DIFF
--- a/evaluate.ts
+++ b/evaluate.ts
@@ -1,7 +1,16 @@
-import type { PSEnv, PSLiteral, PSMap, PSString, PSValue } from "./types.ts";
+import type {
+  PSEnv,
+  PSLiteral,
+  PSMap,
+  PSMapKey,
+  PSRef,
+  PSString,
+  PSValue,
+} from "./types.ts";
 
-import { Operation, parseYAML, run, Task } from "./deps.ts";
+import { parseYAML, run, Task } from "./deps.ts";
 import { yaml2ps } from "./convert.ts";
+import { concat, lookup, map, Maybe } from "./psmap.ts";
 
 export interface EvalOptions {
   filename?: string;
@@ -12,8 +21,9 @@ export function evaluate(
   source: string,
   options?: EvalOptions,
 ): Task<PSValue> {
-  let { filename = "script", context = { type: "map", value: {} } } = options ??
-    {};
+  let { filename = "script", context = { type: "map", value: new Map() } } =
+    options ??
+      {};
   let literal = parse(source, filename);
 
   let env = createYSEnv();
@@ -21,53 +31,119 @@ export function evaluate(
   return run(() => env.eval(literal, context));
 }
 
+type Segment = {
+  type: "const";
+  value: string;
+} | {
+  type: "ref";
+  ref: PSRef;
+};
+
+function* segments(str: PSString): Generator<Segment> {
+  if (str.holes.length) {
+    let idx = 0;
+    for (let hole of str.holes) {
+      let [start, end] = hole.range;
+      let substr = str.value.slice(idx, start);
+      yield {
+        type: "const",
+        value: substr,
+      };
+      yield {
+        type: "ref",
+        ref: hole.ref,
+      };
+      idx = end;
+    }
+    if (idx < str.value.length) {
+      yield {
+        type: "const",
+        value: str.value.slice(idx),
+      };
+    }
+  } else {
+    yield {
+      type: "const",
+      value: str.value,
+    };
+  }
+}
+
 export function createYSEnv(parent = global): PSEnv {
   return {
-    *eval(value, context = { type: "map", value: {} }) {
+    *eval(value, context = { type: "map", value: new Map() }) {
       let scope = concat(parent, context);
       let env = createYSEnv(scope);
 
       if (value.type === "ref") {
-        let { key, path, spec } = value;
+        let [key, ...path] = value.path;
 
-        let result = scope.value[key];
-        if (!result) {
+        let result = lookup(key, scope);
+        if (result.type === "nothing") {
           throw new ReferenceError(`'${value.key}' not defined`);
         } else {
           return path.reduce((current, segment) => {
             if (current.type === "map") {
-              let next = current.value[segment];
-              if (!next) {
-                throw new ReferenceError(`no such key '${segment}' in ${spec}`);
+              let next = lookup(segment, current);
+              if (next.type === "nothing") {
+                throw new ReferenceError(
+                  `no such key '${segment}' in ${value.value}`,
+                );
               } else {
-                return next;
+                return next.value;
               }
             } else {
               throw new TypeError(
                 `cannot de-reference key ${segment} from ${current.type}`,
               );
             }
-          }, result);
+          }, result.value);
         }
+      } else if (value.type === "string") {
+        if (value.holes.length === 0) {
+          return value;
+        }
+        let str = "";
+        for (let segment of segments(value)) {
+          if (segment.type === "const") {
+            str += segment.value;
+          } else {
+            let $val = yield* env.eval(segment.ref);
+            str += $val.value;
+          }
+        }
+        return {
+          type: "string",
+          value: str,
+          holes: [],
+        };
       } else if (value.type === "map") {
-        let map = value.value;
-        let [name] = Object.keys(map);
-        if (!name) {
-          return { type: "boolean", value: false };
-        }
-        let fn = scope.value[name];
-        if (!fn) {
-          throw new Error(`no function defined for '${name}'`);
-        }
-        if (fn.type !== "fn") {
-          throw new Error(`${name} is not a function, it is a ${fn.type}`);
-        }
+        let entries = [...value.value.entries()];
+        let [first, ...rest] = entries;
 
-        return yield* fn.value({
-          arg: map[name],
-          env,
-          rest: exclude({ type: "string", value: name }, value),
-        });
+        if (!first) {
+          return { type: "boolean", value: false };
+        } else {
+          let [key, value] = first;
+          if (key.type === "ref") {
+            let fn = yield* env.eval(key);
+            if (fn.type !== "fn") {
+              throw new Error(
+                `'${key.value}' is not a function, it is a ${fn.type}`,
+              );
+            }
+            return yield* fn.value({
+              arg: value,
+              env,
+              rest: { type: "map", value: new Map(rest) },
+            });
+          } else {
+            return {
+              type: "map",
+              value: new Map(entries),
+            };
+          }
+        }
       } else if (value.type === "list") {
         let result = [] as PSValue[];
         for (let item of value.value) {
@@ -82,14 +158,18 @@ export function createYSEnv(parent = global): PSEnv {
 }
 
 export const letdo = {
-  getBindings(value?: PSValue): PSMap {
-    let bindings = value ?? { type: "map", value: {} };
-    if (bindings.type !== "map") {
-      throw new TypeError(
-        `'let' bindings must be a yaml mapping of keys to values, but it was passed a value of type '${bindings.type}'`,
-      );
+  getBindings(value: Maybe<PSValue>): PSMap {
+    if (value.type === "nothing") {
+      return { type: "map", value: new Map() };
+    } else {
+      let bindings = value.value;
+      if (bindings.type !== "map") {
+        throw new TypeError(
+          `'let' bindings must be a yaml mapping of keys to values, but it was passed a value of type '${bindings.type}'`,
+        );
+      }
+      return bindings;
     }
-    return bindings;
   },
   *do(block: PSValue, bindings: PSMap, env: PSEnv) {
     let scope = yield* map(bindings, env.eval);
@@ -110,75 +190,66 @@ export const letdo = {
 
 export const global: PSMap = {
   type: "map",
-  value: {
-    let: {
+  value: new Map([
+    [{
+      type: "string",
+      value: "let",
+      holes: [],
+    }, {
       type: "fn",
       *value({ arg, env, rest }) {
-        let bindings = letdo.getBindings(arg);
-        let block = rest.value["do"];
-        if (block) {
-          return yield* letdo.do(block, bindings, env);
+        let bindings = letdo.getBindings({ type: "just", value: arg });
+        let block = lookup("$do", rest);
+        if (block.type == "just") {
+          return yield* letdo.do(block.value, bindings, env);
         } else {
           return { type: "boolean", value: false };
         }
       },
-    },
-    do: {
+    }],
+    [{
+      type: "string",
+      value: "do",
+      holes: [],
+    }, {
       type: "fn",
       *value({ arg, env, rest }) {
-        let bindings = letdo.getBindings(rest.value["let"]);
+        let bindings = letdo.getBindings(lookup("$let", rest));
         return yield* letdo.do(arg, bindings, env);
       },
-    },
-  },
+    }],
+  ]),
 };
 
 export function parse(source: string, filename = "script"): PSLiteral<PSValue> {
   let yaml = parseYAML(source, { filename });
+  let [error] = yaml.errors;
   if (!yaml) {
     throw new SyntaxError(`empty string is not a YAML Document`);
+  } else if (error) {
+    throw error;
   }
   return yaml2ps(yaml);
 }
 
-export function concat(parent: PSMap, child: PSMap): PSMap {
-  let properties = Object.keys(child.value).reduce((props, key) => {
-    return Object.assign(props, {
-      [key]: {
-        enumerable: true,
-        configurable: true,
-        get: () => child.value[key],
-      } as PropertyDescriptor,
-    });
-  }, {});
-  return {
-    type: "map",
-    value: Object.create(parent.value, properties),
-  };
-}
-
-export function* map(
-  fntor: PSMap,
-  fn: (value: PSValue) => Operation<PSValue>,
-): Operation<PSMap> {
-  let value: Record<string, PSValue> = {};
-  for (let key of Object.keys(fntor.value)) {
-    value[key] = yield* fn(fntor.value[key]);
+export function strip(literal: PSValue): PSValue {
+  //@ts-expect-error stripping is safe because we're just dropping the node
+  let { node: _, ...value } = literal;
+  if (value.type === "map") {
+    let map = value.value;
+    return {
+      type: "map",
+      value: new Map(
+        [...map.entries()].map(([k, v]) => [strip(k) as PSMapKey, strip(v)]),
+      ),
+    };
+  } else if (value.type === "list") {
+    let list = value.value;
+    return {
+      type: "list",
+      value: list.map((val) => strip(val as PSLiteral<PSValue>)),
+    };
+  } else {
+    return value;
   }
-
-  return { type: "map", value };
-}
-
-export function exclude(key: PSString, map: PSMap) {
-  let result: PSMap = {
-    type: "map",
-    value: {},
-  };
-  for (let k of Object.keys(map.value)) {
-    if (k !== key.value) {
-      result.value[k] = map.value[k];
-    }
-  }
-
-  return result;
 }

--- a/load.ts
+++ b/load.ts
@@ -2,7 +2,8 @@ import type { PSMap, PSModule, PSValue } from "./types.ts";
 import type { Operation } from "./deps.ts";
 
 import { expect, useAbortSignal } from "./deps.ts";
-import { createYSEnv, global, letdo, parse } from "./evaluate.ts";
+import { exclude, lookup } from "./psmap.ts";
+import { createYSEnv, letdo, parse } from "./evaluate.ts";
 
 export function* load(
   location: string | URL,
@@ -13,83 +14,91 @@ export function* load(
 
   let result: PSValue = body;
 
-  let env = createYSEnv();
+  let scope: PSMap = {
+    type: "map",
+    value: new Map(),
+  };
 
   let symbols: PSMap = {
     type: "map",
-    value: {},
+    value: new Map(),
   };
+
+  let env = createYSEnv();
 
   function* importSymbols(map: PSValue): Operation<void> {
     if (map.type !== "map") {
       throw new Error(
-        `imports be specified as a mapping of name: and from:, but was ${map.type}`,
+        `imports must be specified as a mapping of name: and from:, but was ${map.type}`,
       );
     }
-    let { names } = map.value;
-    if (!names) {
+    let names = lookup("names", map);
+    if (names.type === "nothing") {
       throw new Error(`imports must have a list of 'names:'`);
     }
-    if (names.type !== "list") {
+    if (names.value.type !== "list") {
       throw new Error(
         `imported names must be a list, but was '${names.type}`,
       );
     }
-    let { from: source } = map.value;
-    if (!source) {
+    let source = lookup("from", map);
+    if (source.type === "nothing") {
       throw new Error(`imports must have a 'from:' field'`);
     }
-    if (source.type !== "string") {
+    if (source.value.type !== "string") {
       throw new Error(
         `import location should be a string, but was '${source.type}`,
       );
     }
-    let dep = yield* load(source.value, url.toString());
-    for (let name of names.value) {
-      if (name.type !== "ref") {
+    let dep = yield* load(source.value.value, url.toString());
+
+    for (let name of names.value.value) {
+      if (name.type !== "string") {
         throw new Error(
-          `imported names must be references, but found ${name.type}`,
+          `imported names must be strings, but found ${name.type}`,
         );
       }
-      let value = dep.symbols.value[name.key];
-      if (!value) {
+      let value = lookup(name.value, dep.symbols);
+      if (value.type === "nothing") {
         throw new Error(
-          `${source.value} does not define a value named '${name.key}'`,
+          `${source.value.value} does not define a value named '${name.value}'`,
         );
       }
-      symbols.value[name.key] = value;
+      scope.value.set(name, value.value);
     }
   }
 
   if (body.type === "map") {
-    let { import: imports, do: script, ...values } = body.value;
-    if (imports) {
-      if (imports.type === "map") {
-        yield* importSymbols(imports);
-      } else if (imports.type === "list") {
-        for (let mapping of imports.value) {
+    let imports = lookup("$import", body);
+    let script = lookup("$do", body);
+    let exports = exclude(["$import", "$do"], body);
+
+    if (imports.type === "just") {
+      if (imports.value.type === "map") {
+        yield* importSymbols(imports.value);
+      } else if (imports.value.type === "list") {
+        for (let mapping of imports.value.value) {
           yield* importSymbols(mapping);
         }
       } else {
         throw new Error(
-          `imports must be specified as a list or a mapping, but it was ${imports.type}`,
+          `imports must be specified as a list or a mapping, but it was ${imports.value.type}`,
         );
       }
     }
-    for (let key of Object.keys(values)) {
-      if (hasKey(key, global)) {
-        throw new Error(`cannot override global operation '${key}'`);
-      } else {
-        symbols.value[key] = yield* env.eval(body.value[key], symbols);
-      }
+    for (let [key, value] of exports.value.entries()) {
+      let $value = yield* env.eval(value, scope);
+      scope.value.set(key, $value);
+      symbols.value.set(key, $value);
     }
-    if (script) {
-      result = yield* letdo.do(script, symbols, env);
+
+    if (script.type === "just") {
+      result = yield* letdo.do(script.value, scope, env);
     } else {
       result = { type: "boolean", value: false };
     }
   } else if (body.type === "list") {
-    result = yield* letdo.do(body, symbols, env);
+    result = yield* letdo.do(body, scope, env);
   }
 
   return {
@@ -125,8 +134,4 @@ function* read(url: URL): Operation<string> {
       `cannot load module from ${url}: unsupported protocol '${url.protocol}'`,
     );
   }
-}
-
-function hasKey(key: string, map: PSMap): boolean {
-  return key in map.value;
 }

--- a/psmap.ts
+++ b/psmap.ts
@@ -1,0 +1,64 @@
+import type { PSMap, PSMapKey, PSValue } from "./types.ts";
+import type { Operation } from "./deps.ts";
+
+export function concat(parent: PSMap, child: PSMap): PSMap {
+  return {
+    type: "map",
+    value: new Map([...parent.value.entries(), ...child.value.entries()]),
+  };
+}
+
+export function* map(
+  fntor: PSMap,
+  fn: (value: PSValue) => Operation<PSValue>,
+): Operation<PSMap> {
+  let entries: [PSMapKey, PSValue][] = [];
+  for (let [k, v] of fntor.value.entries()) {
+    entries.push([k, yield* fn(v)]);
+  }
+
+  return { type: "map", value: new Map(entries) };
+}
+
+export type Maybe<T> =
+  | {
+    type: "just";
+    value: T;
+  }
+  | {
+    type: "nothing";
+    value: void;
+  };
+
+export function lookup(key: string, map: PSMap): Maybe<PSValue> {
+  for (let entry of map.value.entries()) {
+    let [k, value] = entry;
+    if (k.value.toString() === key) {
+      return { type: "just", value };
+    }
+  }
+  return { type: "nothing", value: void 0 };
+}
+
+export function lookup$(key: string, map: PSMap): PSValue {
+  let maybe = lookup(key, map);
+  if (maybe.type === "nothing") {
+    throw new Error(`expected map to contain key '${key}', but it did not`);
+  }
+  return maybe.value;
+}
+
+export function exclude(keys: string[], map: PSMap): PSMap {
+  return {
+    type: "map",
+    value: new Map({
+      *[Symbol.iterator]() {
+        for (let [key, value] of map.value.entries()) {
+          if (!keys.includes(key.value.toString())) {
+            yield [key, value];
+          }
+        }
+      },
+    }),
+  };
+}

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from "./suite.ts";
-import { parse, PSLiteral, PSMap } from "../mod.ts";
+import { parse } from "../mod.ts";
+import type { PSFn } from "../types.ts";
 
 describe("function literal", () => {
-  it("can be defined in a map", () => {
-    let map = parse("id(x): x") as PSLiteral<PSMap>;
-    let fn = map.value.id;
-    expect(fn).toBeDefined();
+  it("is defined as a mapping", () => {
+    let fn = parse("$(x): $x") as PSFn;
     expect(fn.type).toEqual("fn");
   });
 });

--- a/test/match-refs.test.ts
+++ b/test/match-refs.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "./suite.ts";
+
+import { matchRefs } from "../convert.ts";
+
+describe("matching references", () => {
+  it("can match several referenrces across multiple lines", () => {
+    let match = matchRefs(`$one  $two.xyz
+$three
+`);
+    expect(match.total).toEqual(false);
+    expect(match.holes.length).toEqual(3);
+    let [one, two, three] = match.holes;
+    expect(one.range).toEqual([0, 4]);
+    expect(two.range).toEqual([6, 14]);
+    expect(three.range).toEqual([15, 21]);
+
+    let ref = two.ref;
+    expect(ref.value).toEqual("$two.xyz");
+    expect(ref.key).toEqual("two");
+    expect(ref.path).toEqual(["two", "xyz"]);
+  });
+
+  it("recognizes when the reference is the entirety of the string", () => {
+    expect(matchRefs("$one").total).toEqual(true);
+  });
+});

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -4,6 +4,7 @@ import type { Task } from "../deps.ts";
 import { describe, expect, it, useStaticFileServer } from "./suite.ts";
 import { evaluate, load, ps2js } from "../mod.ts";
 import { run } from "../deps.ts";
+import { lookup, lookup$ } from "../psmap.ts";
 
 describe("a PlatformScript module", () => {
   it("can be loaded from an absolute url", async () => {
@@ -16,22 +17,19 @@ describe("a PlatformScript module", () => {
     let mod = await loadmod("nodeps.yaml");
     let symbols = mod.symbols;
 
-    expect(ps2js(symbols.value.five)).toEqual(5);
-    expect(symbols.value.id.type).toEqual("fn");
+    expect(lookup$("five", symbols).value).toEqual(5);
+    expect(lookup$("str", symbols).value).toEqual("world");
+    expect(lookup$("id", symbols).type).toEqual("fn");
   });
   it("can load other modules from a relative url", async () => {
     let mod = await loadmod("imports-relative.yaml");
-    expect(mod.symbols.value.five.type).toEqual("number");
-
-    expect(ps2js(mod.symbols.value.five)).toEqual(5);
-    expect(mod.symbols.value.hello.type).toEqual("string");
-
-    expect(ps2js(mod.symbols.value.hello)).toEqual("hello world");
+    expect(lookup$("myfive", mod.symbols).value).toEqual(5);
+    expect(lookup$("hello", mod.symbols).value).toEqual("hello world");
   });
 
   it("does not import symbols that are not expliticly mapped", async () => {
     let mod = await loadmod("imports-relative.yaml");
-    expect(mod.symbols.value.str).not.toBeDefined();
+    expect(lookup("str", mod.symbols).type).toEqual("nothing");
   });
 
   it("throws an error if the symbol does not exist in the source module", async () => {
@@ -45,8 +43,8 @@ describe("a PlatformScript module", () => {
 
   it("can be specified using a TypeScript module", async () => {
     let mod = await loadmod("module.yaml.ts");
-    let result = await evaluate(`{to-string: 100 }`, { context: mod.symbols });
-    expect(result).toEqual({ type: "string", value: "100" });
+    let result = await evaluate(`{$to-string: 100 }`, { context: mod.symbols });
+    expect(result).toEqual({ type: "string", value: "100", holes: [] });
   });
 
   it("can support a `do` expression at the module level", async () => {
@@ -70,6 +68,7 @@ describe("a PlatformScript module", () => {
       expect(ps2js(mod.value)).toEqual([5, "hello world"]);
     });
   });
+  // it("does not re-export symbols from other modules")
   // it("can remap names of imported symbols");
   // it("can load other modules from an absolute url");
   // it("can use imported symbols from another module");

--- a/test/modules/do.yaml
+++ b/test/modules/do.yaml
@@ -1,5 +1,5 @@
-import:
+$import:
   names: [id]
   from: "./nodeps.yaml"
-do:
-  id: "hello from do"
+$do:
+  $id: "hello from do"

--- a/test/modules/imports-relative.yaml
+++ b/test/modules/imports-relative.yaml
@@ -1,6 +1,6 @@
-import:
+$import:
   names: [five, id]
   from: "./nodeps.yaml"
 
-myfive: five
-hello: { id: "hello world" }
+myfive: $five
+hello: { $id: "hello world" }

--- a/test/modules/module.yaml.ts
+++ b/test/modules/module.yaml.ts
@@ -8,17 +8,20 @@ function ys2string(value: PSValue): PSString {
       return {
         type: "string",
         value: String(value.value),
+        holes: [],
       };
     case "number":
       return {
         type: "string",
         value: String(value.value),
+        holes: [],
       };
     case "list": {
       let elements = value.value.map((v) => ys2string(v).value);
       return {
         type: "string",
         value: `[${elements.join(",")}]`,
+        holes: [],
       };
     }
     case "map": {
@@ -28,30 +31,34 @@ function ys2string(value: PSValue): PSString {
       return {
         type: "string",
         value: `{${pairs.join(",")}}`,
+        holes: [],
       };
     }
     case "ref":
       return {
         type: "string",
         value: `^${value.key}`,
+        holes: [],
       };
     case "fn":
       return {
         type: "string",
         value: `[fn]`,
+        holes: [],
       };
   }
 }
 
 export default {
   type: "map",
-  value: {
-    "to-string": {
+  value: new Map([[
+    { type: "string", value: "to-string", holes: [] },
+    {
       type: "fn",
       *value({ arg, env }) {
         let $arg = yield* env.eval(arg);
         return ys2string($arg);
       },
     } as PSFn,
-  },
+  ]]),
 } as PSMap;

--- a/test/modules/multi-dep.yaml
+++ b/test/modules/multi-dep.yaml
@@ -1,8 +1,8 @@
-import:
+$import:
  - names: [five, id]
    from: "./nodeps.yaml"
  - names: [hello]
    from: "./imports-relative.yaml"
 
-do:
-  - id: [five, hello]
+$do:
+  - $id: [$five, $hello]

--- a/test/modules/no-such-symbol.yaml
+++ b/test/modules/no-such-symbol.yaml
@@ -1,3 +1,3 @@
-import:
+$import:
   names: [blork]
   from: "./nodeps.yaml"

--- a/test/modules/nodeps.yaml
+++ b/test/modules/nodeps.yaml
@@ -1,3 +1,3 @@
 five: 5
-id(x): x
+id: { $(x): $x }
 str: "world"

--- a/test/ref.test.ts
+++ b/test/ref.test.ts
@@ -2,16 +2,16 @@ import { describe, eval2js, expect, it } from "./suite.ts";
 
 describe("a reference", () => {
   it("evaluates a simple value", async () => {
-    expect(await eval2js(`five`, { five: 5 })).toEqual(5);
+    expect(await eval2js(`$five`, { five: 5 })).toEqual(5);
   });
   it("evaluates a value nested in a map", async () => {
     expect(
-      await eval2js("numbers.ints.five", { numbers: { ints: { five: 5 } } }),
+      await eval2js("$numbers.ints.five", { numbers: { ints: { five: 5 } } }),
     ).toEqual(5);
   });
   it("fails to evaluate if the value does not exist", async () => {
     try {
-      await eval2js("empty.nothing", { empty: {} });
+      await eval2js("$empty.nothing", { empty: {} });
       throw new Error("expected dereference to fail, but it did not");
     } catch (error) {
       expect(error.message).toMatch(/no such key/);

--- a/types.ts
+++ b/types.ts
@@ -20,6 +20,14 @@ export type PSValue =
   | PSMap
   | PSFn;
 
+export type PSMapKey =
+  | PSNumber
+  | PSBoolean
+  | PSString
+  | PSRef;
+
+export type PSMapEntry = [PSMapKey, PSValue];
+
 export type PSLiteral<T extends PSValue> = T & {
   node: YAMLNode;
 };
@@ -37,11 +45,12 @@ export interface PSBoolean {
 export interface PSString {
   type: "string";
   value: string;
+  holes: { ref: PSRef; range: [number, number] }[];
 }
 
 export interface PSRef {
   type: "ref";
-  spec: string;
+  value: string;
   key: string;
   path: string[];
 }
@@ -53,7 +62,7 @@ export interface PSList {
 
 export interface PSMap {
   type: "map";
-  value: Record<string, PSValue>;
+  value: Map<PSMapKey, PSValue>;
 }
 
 export interface PSFn {


### PR DESCRIPTION
## Motivation
Because our current references are just "non-quoted" strings, it means that there is no way to disabmiguate them from other strings if they pass through another languge. Imagine, for example, that we parse the followinrg PlatformScript into JSON

```yaml
- reference
- "reference"
```

This contains a list of two references but when we parse it into its equilavent JSON, we get:

```json
[
  "reference",
  "reference",
]
```

There is no way to tell which one is the reference and which one is the string even if we convert it back to YAML. Unfortunately, when it comes to embedding YAML into various places, this is all to common that it is parsed into memory, and then re-serialized later, potentially losing key information.

## Approach
Our solution to this is to explicitly mark anything that should be a reference with a `$` sigil.

So this:

```yaml
import:
 - names: [five, id]
   from: "./nodeps.yaml"
 - names: [hello]
   from: "./imports-relative.yaml"

do:
  - id: [five, hello]
```

becomes this:

```yaml
$import:
 - names: [five, id]
   from: "./nodeps.yaml"
 - names: [hello]
   from: "./imports-relative.yaml"

$do:
  - $id: [$five, $hello]
```

The above can be parsed, and re-serialized, and still be executed correctly, whereas the same is not true of the first.

### TODOs and Open Questions

This ameliorates the problem, but it does not solve it. For example, what do we do with this situation:

```
- $reference
- '$reference'
```

We should either say: "$x", '$x', and $x all are the same thing (probably the best idea?), and then have an escaping sequence.

This also includes a spike on string interpolation which wasn't strictly necessary, but it got intermingled with this change inextricably while I was trying to determine the ramifications of mixing strings and references. As a result, each double quoted string, and unquoted string has a number of "holes" which need to be plugged before the string can be rendered. Right now, the only thing that can plug a hole is a reference, and in fact it is the presence of the references that marks the hole. This brings up the following questions:

* what is the best syntax for holes. It should have the ability to embed arbitrary PlatformScript expressions in them and not just references. Some of the proposals: `$()`, `%()`, `(())`, E.g.

```yaml
Hello %({$capitalize: "world" })
```
* Should there be a separte type for a string template? Right now any string can have holes, but maybe we should represent it as `PSTemplate`? This feels more right than what we have now.