### PR TITLE
Enable publishing to NPM

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,47 @@
+# This workflow will install Deno then run Deno lint and test.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Release to NPM
+
+on:
+  push:
+    tags:
+      - "platformscript-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Get Version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
+
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          registry-url: https://registry.npmjs.com
+
+      - name: Build
+        run: deno task build:npm $NPM_VERSION
+        env:
+          NPM_VERSION: ${{steps.vars.outputs.version}}
+
+      - name: Publish
+        run: npm publish --access=public
+        working-directory: ./build/npm
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /package*
 /node_modules/
 /build
+/deno.lock

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -18,27 +18,28 @@ await build({
   test: false,
   typeCheck: false,
   compilerOptions: {
+    lib: ["esnext", "dom"],
     target: "ES2020",
     sourceMap: true,
   },
   package: {
     // package.json properties
-    name: "@frontside/PlatformScript",
+    name: "platformscript",
     version,
-    description: "Program with YAML",
+    description: "Bring your YAML to life",
     license: "ISC",
     repository: {
       author: "engineering@frontside.com",
       type: "git",
-      url: "git+https://github.com/frontside/PlatformScript.git",
+      url: "git+https://github.com/frontside/platformscript.git",
     },
     bugs: {
-      url: "https://github.com/frontside/PlatformScript/issues",
+      url: "https://github.com/frontside/platformscript/issues",
     },
     engines: {
-      node: ">= 14",
+      node: ">= 16",
     },
   },
 });
 
-await Deno.copyFile("../README.md", `${outDir}/README.md`);
+await Deno.copyFile("README.md", `${outDir}/README.md`);


### PR DESCRIPTION
## Motivation

In order to use PlatformScript inside Browser applications that are build with Node tooling, as well as being able to use it from within Node itself, we will need to publish it to NPM.

## Approach

<!-- REQUIRED
  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
-->



This uses https://github.com/denoland/dnt in order to build an NPM package out of a ES module

Every time a tag like `platformscript-v1.0.0` is published, it will build the npm package and push it to npmjs.com. This uses the tag name as the sole source of truth. If there is a tag, it will be published. It is up to other logic to decide when to tag and when not to tag.