### PR TITLE
Add API for easy embedding

### DIFF
--- a/evaluate.ts
+++ b/evaluate.ts
@@ -8,28 +8,9 @@ import type {
   PSValue,
 } from "./types.ts";
 
-import { parseYAML, run, Task } from "./deps.ts";
+import { parseYAML } from "./deps.ts";
 import { yaml2ps } from "./convert.ts";
 import { concat, lookup, map, Maybe } from "./psmap.ts";
-
-export interface EvalOptions {
-  filename?: string;
-  context?: PSMap;
-}
-
-export function evaluate(
-  source: string,
-  options?: EvalOptions,
-): Task<PSValue> {
-  let { filename = "script", context = { type: "map", value: new Map() } } =
-    options ??
-      {};
-  let literal = parse(source, filename);
-
-  let env = createYSEnv();
-
-  return run(() => env.eval(literal, context));
-}
 
 type Segment = {
   type: "const";

--- a/mod.ts
+++ b/mod.ts
@@ -2,3 +2,4 @@ export * from "./types.ts";
 export * from "./convert.ts";
 export * from "./evaluate.ts";
 export * from "./load.ts";
+export * from "./platformscript.ts";

--- a/platformscript.ts
+++ b/platformscript.ts
@@ -1,0 +1,29 @@
+import type { PSMap, PSModule, PSValue } from "./types.ts";
+import type { Task } from "./deps.ts";
+import { createYSEnv, global, parse } from "./evaluate.ts";
+import { concat, createPSMap } from "./psmap.ts";
+import { load } from "./load.ts";
+import { run } from "./deps.ts";
+
+export interface PlatformScript {
+  eval(value: PSValue, bindings?: PSMap): Task<PSValue>;
+  load(url: string | URL, base?: string): Task<PSModule>;
+  parse(source: string, filename?: string): PSValue;
+}
+
+export function createPlatformScript(extensions?: PSMap): PlatformScript {
+  let ext = extensions ?? createPSMap();
+  let env = createYSEnv(concat(global, ext));
+
+  return {
+    eval(value, bindings) {
+      return run(() => env.eval(value, bindings));
+    },
+    load(location, base) {
+      return run(() => load({ location, base, env }));
+    },
+    parse(source, filename) {
+      return parse(source, filename);
+    },
+  };
+}

--- a/psmap.ts
+++ b/psmap.ts
@@ -1,6 +1,13 @@
 import type { PSMap, PSMapKey, PSValue } from "./types.ts";
 import type { Operation } from "./deps.ts";
 
+export function createPSMap(): PSMap {
+  return {
+    type: "map",
+    value: new Map(),
+  };
+}
+
 export function concat(parent: PSMap, child: PSMap): PSMap {
   return {
     type: "map",

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -1,8 +1,14 @@
 import type { PSModule } from "../types.ts";
 import type { Task } from "../deps.ts";
 
-import { describe, expect, it, useStaticFileServer } from "./suite.ts";
-import { evaluate, load, ps2js } from "../mod.ts";
+import {
+  describe,
+  evaluate,
+  expect,
+  it,
+  useStaticFileServer,
+} from "./suite.ts";
+import { load, ps2js } from "../mod.ts";
 import { run } from "../deps.ts";
 import { lookup, lookup$ } from "../psmap.ts";
 
@@ -43,7 +49,7 @@ describe("a PlatformScript module", () => {
 
   it("can be specified using a TypeScript module", async () => {
     let mod = await loadmod("module.yaml.ts");
-    let result = await evaluate(`{$to-string: 100 }`, { context: mod.symbols });
+    let result = await evaluate(`{$to-string: 100 }`, mod.symbols);
     expect(result).toEqual({ type: "string", value: "100", holes: [] });
   });
 
@@ -64,7 +70,9 @@ describe("a PlatformScript module", () => {
   it("supports loading both from the network and from local file system", async () => {
     await run(function* () {
       let { hostname, port } = yield* useStaticFileServer("test/modules");
-      let mod = yield* load(`http://${hostname}:${port}/multi-dep.yaml`);
+      let mod = yield* load({
+        location: `http://${hostname}:${port}/multi-dep.yaml`,
+      });
       expect(ps2js(mod.value)).toEqual([5, "hello world"]);
     });
   });
@@ -77,5 +85,9 @@ describe("a PlatformScript module", () => {
 });
 
 function loadmod(url: string): Task<PSModule> {
-  return run(() => load(new URL(`modules/${url}`, import.meta.url)));
+  return run(() =>
+    load({
+      location: new URL(`modules/${url}`, import.meta.url),
+    })
+  );
 }

--- a/test/modules/module.yaml.ts
+++ b/test/modules/module.yaml.ts
@@ -25,7 +25,7 @@ function ys2string(value: PSValue): PSString {
       };
     }
     case "map": {
-      let pairs = Object.entries(value.value).map(([k, v]) =>
+      let pairs = [...value.value.entries()].map(([k, v]) =>
         `${k}: ${ys2string(v).value}`
       );
       return {

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -1,15 +1,19 @@
 export * from "https://deno.land/std@0.145.0/testing/bdd.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.9/mod.ts";
 
-import { evaluate, js2ps, ps2js, PSMap } from "../mod.ts";
+import { createPlatformScript, js2ps, ps2js, PSMap } from "../mod.ts";
+
+export function evaluate(source: string, scope?: PSMap) {
+  let ps = createPlatformScript();
+  let value = ps.parse(source, "script");
+  return ps.eval(value, scope);
+}
 
 export async function eval2js(
   source: string,
   cxt: Record<string, unknown> = {},
 ): Promise<unknown> {
-  let result = await evaluate(source, {
-    context: js2ps(cxt) as PSMap,
-  });
+  let result = await evaluate(source, js2ps(cxt) as PSMap);
   return ps2js(result);
 }
 

--- a/types.ts
+++ b/types.ts
@@ -62,7 +62,7 @@ export interface PSList {
 
 export interface PSMap {
   type: "map";
-  value: Map<PSMapKey, PSValue>;
+  value: Pick<Map<PSMapKey, PSValue>, "get" | "set" | "entries">;
 }
 
 export interface PSFn {


### PR DESCRIPTION
## Motivation
In order to use platform script it needs to be easy to instantiate and call from within Deno, Browser, and Node. To do this, we need to present a one-stop api where you can define your global scope, and then either load modules or execute snippets from within it.

## Approach
This defines a single interface `PlatformScript` which deals only in Promise compatible APIs. The globals that you pass into this environment will be available in all modules and snippets it runs:

```js
import { myglobals } from "./my-custom-globals";

let ps = createPlatformScript(myglobals);
await ps.load("https://some.fun/module.yaml");
```
