### PR TITLE
🐛 NPM release was broken because of a bad tag prefix

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get Version
         id: vars
-        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
+        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^platformscript-v//')
 
 
       - name: Setup Node


### PR DESCRIPTION
## Motivation
The tag is not vx.x.x like in graphgen, but instead platformscript-vx.x.x because this will be a monorepo housing multiple release histories.

See
https://github.com/thefrontside/platformscript/actions/runs/3494201486/jobs/5849774121 for details.

## Approach
Updates the `sed` script which strips out the version prefix to contain the correct version prefix.
