### PR TITLE
Update NPM package to point to the correct repository urls

### DIFF
--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -31,10 +31,10 @@ await build({
     repository: {
       author: "engineering@frontside.com",
       type: "git",
-      url: "git+https://github.com/frontside/platformscript.git",
+      url: "git+https://github.com/thefrontside/platformscript.git",
     },
     bugs: {
-      url: "https://github.com/frontside/platformscript/issues",
+      url: "https://github.com/thefrontside/platformscript/issues",
     },
     engines: {
       node: ">= 16",


### PR DESCRIPTION
## Motivation

It points to the wrong URL and 404s from https://www.npmjs.com/package/platformscript/v/1.0.0-alpha.2