### PR TITLE
Embed external values into PlatformScript

### DIFF
--- a/data.ts
+++ b/data.ts
@@ -1,0 +1,58 @@
+import type {
+  PSBoolean,
+  PSExternal,
+  PSFn,
+  PSList,
+  PSMap,
+  PSNumber,
+  PSRef,
+  PSString,
+  PSValue,
+} from "./types.ts";
+
+export function number(value: number): PSNumber {
+  return { type: "number", value };
+}
+
+export function boolean(value: boolean): PSBoolean {
+  return { type: "boolean", value };
+}
+
+export function string(value: string): PSString {
+  return { type: "string", value };
+}
+
+export function ref(key: string, path: string[]): PSRef {
+  return {
+    type: "ref",
+    value: `$${[key].concat(path).join(".")}`,
+    key,
+    path,
+  };
+}
+
+export function list(value: PSValue[]): PSList {
+  return { type: "list", value };
+}
+
+export function map(value: Record<string, PSValue>): PSMap {
+  return {
+    type: "map",
+    value: new Map(
+      Object.entries(value).map(([k, v]) => {
+        return [string(k), v];
+      }),
+    ),
+  };
+}
+
+export function external(
+  value: unknown,
+  view?: PSExternal["view"],
+): PSExternal {
+  return { type: "external", value, view };
+}
+
+export function fn(value: PSFn["value"]): PSFn {
+  return { type: "fn", value };
+}

--- a/mod.ts
+++ b/mod.ts
@@ -3,3 +3,4 @@ export * from "./convert.ts";
 export * from "./evaluate.ts";
 export * from "./load.ts";
 export * from "./platformscript.ts";
+export * from "./data.ts";

--- a/test/external.test.ts
+++ b/test/external.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "./suite.ts";
+import { createPlatformScript, external, map, number } from "../mod.ts";
+
+import * as _ from "https://raw.githubusercontent.com/lodash/lodash/4.17.21-es/lodash.js";
+
+describe("external", () => {
+  it("can represent any arbitrary javascript value", async () => {
+    let obj = { unqiue: "object" };
+    let ps = createPlatformScript(map({
+      "extern": external(obj),
+    }));
+    expect((await ps.eval(ps.parse("$extern"))).value).toBe(obj);
+  });
+
+  it("can define new PS values from the external value", async () => {
+    let obj = { I: { contain: { the: { number: number(5) } } } };
+    let ps = createPlatformScript(map({
+      "truly": external(obj, (path, o) => _.get(o, path)),
+    }));
+
+    let program = ps.parse("$truly.I.contain.the.number");
+    expect((await ps.eval(program)).value).toEqual(5);
+  });
+  it("errors if a dereference is undefined", async () => {
+    let ps = createPlatformScript(map({
+      "oops": external({}, () => void 0),
+    }));
+    try {
+      await ps.eval(ps.parse("$oops.i.did.it.again"));
+      throw new Error("expected block to throw, but it did not");
+    } catch (error) {
+      expect(error.name).toEqual("ReferenceError");
+    }
+  });
+  it("errors if a derefenence does not return a PSValue", async () => {
+    let ps = createPlatformScript(map({
+      "oops": external(
+        { wrong: "type" },
+        //@ts-expect-error situation could happen if you are using JavaScript...
+        () => ({ type: "WAT!!", value: "hi" }),
+      ),
+    }));
+
+    try {
+      await ps.eval(ps.parse("$oops.wrong"));
+      throw new Error("expected block to throw, but it did not");
+    } catch (error) {
+      expect(error.message).toMatch(
+        /did not resolve to a platformscript value/,
+      );
+      expect(error.name).toEqual("TypeError");
+    }
+  });
+  // it("can handle an exception that happens during dereference");
+});

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,4 @@
+//deno-lint-ignore-file no-explicit-any
 import { Operation, YAMLNode } from "./deps.ts";
 
 export interface PSEnv {
@@ -19,7 +20,8 @@ export type PSValue =
   | PSRef
   | PSList
   | PSMap
-  | PSFn;
+  | PSFn
+  | PSExternal;
 
 export type PSMapKey =
   | PSNumber
@@ -70,6 +72,12 @@ export interface PSList {
 export interface PSMap {
   type: "map";
   value: Pick<Map<PSMapKey, PSValue>, "get" | "set" | "entries">;
+}
+
+export interface PSExternal {
+  type: "external";
+  value: any;
+  view?(path: string[], value: any): PSValue | void;
 }
 
 export interface PSFn {


### PR DESCRIPTION
## Motivation
The entire point of PlatformScript is to compose pieces of the platform. In order to do that, we have to be able to represent those pieces as PlatformScript values that can be passed around.

## Approach
This introduces a new type `PSExternal` which can appear anywhere a `PSValue` can. It supports de-referencing via an optional `view` property which is a function receiving a path that should produce a new `PSValue`

To help creating values for embedders, there is a set of top-level constructors for creating PlatformScript values from JavaScript values. e.g.

```ts
import * as ps from 'platformscript';

let scope = ps.map({
  num: ps.number(10),
  bool: ps.boolean(true),
  extern: ps.external({ weather: "sunny"}, (path, obj) => ps.string(lodash.get(obj, path))),
})

let platformscript = ps.createPlatformScript(scope);

let prog = platformscript.parse("Hello %($num). That is %($bool). Weather is %($extern.weather)");

await platformscript.eval(prog);
```