### PR TITLE
Add function call syntax

### DIFF
--- a/evaluate.ts
+++ b/evaluate.ts
@@ -151,6 +151,9 @@ export function createYSEnv(parent = global): PSEnv {
         return value;
       }
     },
+    *call(fn, funcall) {
+      return yield* fn.value(funcall);
+    },
   };
 }
 

--- a/platformscript.ts
+++ b/platformscript.ts
@@ -1,4 +1,4 @@
-import type { PSMap, PSModule, PSValue } from "./types.ts";
+import type { PSFn, PSFnCall, PSMap, PSModule, PSValue } from "./types.ts";
 import type { Task } from "./deps.ts";
 import { createYSEnv, global, parse } from "./evaluate.ts";
 import { concat, createPSMap } from "./psmap.ts";
@@ -6,6 +6,7 @@ import { load } from "./load.ts";
 import { run } from "./deps.ts";
 
 export interface PlatformScript {
+  call(fn: PSFn, funcall: PSFnCall): Task<PSValue>;
   eval(value: PSValue, bindings?: PSMap): Task<PSValue>;
   load(url: string | URL, base?: string): Task<PSModule>;
   parse(source: string, filename?: string): PSValue;
@@ -16,6 +17,9 @@ export function createPlatformScript(extensions?: PSMap): PlatformScript {
   let env = createYSEnv(concat(global, ext));
 
   return {
+    call(fn, funcall) {
+      return run(() => env.call(fn, funcall));
+    },
     eval(value, bindings) {
       return run(() => env.eval(value, bindings));
     },

--- a/test/fn.test.ts
+++ b/test/fn.test.ts
@@ -1,0 +1,18 @@
+import { assert, describe, expect, it } from "./suite.ts";
+import * as ps from "../mod.ts";
+
+describe("fn", () => {
+  it("can be called directly", async () => {
+    let interp = ps.createPlatformScript();
+    let program = interp.parse("$(thing): Hello %($thing)!");
+    let fn = await interp.eval(program);
+    assert(fn.type === "fn");
+    expect(
+      (await interp.call(fn, {
+        arg: ps.string("World"),
+        rest: ps.map({}),
+        env: ps.createYSEnv(),
+      })).value,
+    ).toEqual("Hello World!");
+  });
+});

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -1,5 +1,6 @@
 export * from "https://deno.land/std@0.145.0/testing/bdd.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.9/mod.ts";
+export * from "https://deno.land/std@0.165.0/testing/asserts.ts";
 
 import { createPlatformScript, js2ps, ps2js, PSMap } from "../mod.ts";
 

--- a/types.ts
+++ b/types.ts
@@ -3,6 +3,7 @@ import { Operation, YAMLNode } from "./deps.ts";
 
 export interface PSEnv {
   eval(value: PSValue, scope?: PSMap): Operation<PSValue>;
+  call(fn: PSFn, funcall: PSFnCall): Operation<PSValue>;
 }
 
 export interface PSModule {


### PR DESCRIPTION
## Motivation

When performing callbacks, you need a way to invoke functions directly within an environment.

## Approach
Add a `call` function to the `PSEnv` api and embedders api to call it.
