### PR TITLE
Recursively evaluate map values

### DIFF
--- a/convert.ts
+++ b/convert.ts
@@ -76,7 +76,7 @@ export function ps2js(value: PSValue): unknown {
       return value.value.map(ps2js);
     case "map":
       return [...value.value.entries()].reduce((obj, [k, v]) => {
-        return Object.assign(obj, { [k.value.toString()]: v });
+        return Object.assign(obj, { [k.value.toString()]: ps2js(v) });
       }, {});
     case "fn":
       throw new Error("TODO: convert PlatformScript fn into callable JS fn");

--- a/evaluate.ts
+++ b/evaluate.ts
@@ -135,9 +135,13 @@ export function createYSEnv(parent = global): PSEnv {
               rest: { type: "map", value: new Map(rest) },
             });
           } else {
+            let $entries = [] as [PSMapKey, PSValue][];
+            for (let [k, v] of entries) {
+              $entries.push([k, yield* env.eval(v)]);
+            }
             return {
               type: "map",
-              value: new Map(entries),
+              value: new Map($entries),
             };
           }
         }

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -45,13 +45,15 @@ describe("evaluate()", () => {
     }
   });
 
-  it.ignore("can evaluate a function with map arguments", () => {
-    expect(eval2js("join: { hello: 'world'}", {
-      join: (args: Record<string, unknown>) => {
-        let [[what, to]] = Object.entries(args);
-        return `${what} ${to}`;
-      },
-    })).toEqual("hello world");
+  it("recursively evaluates a map key", async () => {
+    expect(
+      await eval2js(`
+$let:
+  x: "World"
+$do:
+  message: Hello %($x)
+`),
+    ).toEqual({ message: "Hello World" });
   });
 
   describe("do/let", () => {


### PR DESCRIPTION
## Motivation

When reducing a tree of PlatformScript you need to be able to define maps of values that are also themselves reduced, otherwise there is no way to define code that calls functions that evaluate other functions by passing pieces of their body to them as arguments.

In other words in the `say` function:

```yaml
$let:
  to: World
$do:
  $say:
    hello: $to
```

it would have passed the tree `hello: $to` with a reference literal as the value of the key `hello`.  But that's not helpful.

## Approach

Now, however, when we evaluate a map, we create a new map that has the exact same keys as the old map, but the difference is that that values are evaluated. In the above example, the `say` function will receive the mapping: `hello: world` as we would expect.