### PR TITLE
add `run()` to platformscript interpreter

### DIFF
--- a/evaluate.ts
+++ b/evaluate.ts
@@ -10,6 +10,7 @@ import type {
 import { parseYAML } from "./deps.ts";
 import { yaml2ps } from "./convert.ts";
 import { concat, lookup, map, Maybe } from "./psmap.ts";
+import * as data from "./data.ts";
 
 type Segment = {
   type: "const";
@@ -51,7 +52,7 @@ function* segments(t: PSTemplate): Generator<Segment> {
 }
 
 export function createYSEnv(parent = global): PSEnv {
-  return {
+  let env: PSEnv = {
     *eval(value, context = { type: "map", value: new Map() }) {
       let scope = concat(parent, context);
       let env = createYSEnv(scope);
@@ -151,10 +152,15 @@ export function createYSEnv(parent = global): PSEnv {
         return value;
       }
     },
-    *call(fn, funcall) {
-      return yield* fn.value(funcall);
+    call(fn, arg, options) {
+      return fn.value({
+        arg,
+        env,
+        rest: options ?? data.map({}),
+      });
     },
   };
+  return env;
 }
 
 export const letdo = {

--- a/test/external.test.ts
+++ b/test/external.test.ts
@@ -1,48 +1,56 @@
 import { describe, expect, it } from "./suite.ts";
-import { createPlatformScript, external, map, number } from "../mod.ts";
+import { createPlatformScript, external, map, number, parse } from "../mod.ts";
 
 import * as _ from "https://raw.githubusercontent.com/lodash/lodash/4.17.21-es/lodash.js";
 
 describe("external", () => {
   it("can represent any arbitrary javascript value", async () => {
     let obj = { unqiue: "object" };
-    let ps = createPlatformScript(map({
-      "extern": external(obj),
-    }));
-    expect((await ps.eval(ps.parse("$extern"))).value).toBe(obj);
+    let ps = createPlatformScript(() =>
+      map({
+        "extern": external(obj),
+      })
+    );
+    expect((await ps.eval(parse("$extern"))).value).toBe(obj);
   });
 
   it("can define new PS values from the external value", async () => {
     let obj = { I: { contain: { the: { number: number(5) } } } };
-    let ps = createPlatformScript(map({
-      "truly": external(obj, (path, o) => _.get(o, path)),
-    }));
+    let ps = createPlatformScript(() =>
+      map({
+        "truly": external(obj, (path, o) => _.get(o, path)),
+      })
+    );
 
-    let program = ps.parse("$truly.I.contain.the.number");
+    let program = parse("$truly.I.contain.the.number");
     expect((await ps.eval(program)).value).toEqual(5);
   });
   it("errors if a dereference is undefined", async () => {
-    let ps = createPlatformScript(map({
-      "oops": external({}, () => void 0),
-    }));
+    let ps = createPlatformScript(() =>
+      map({
+        "oops": external({}, () => void 0),
+      })
+    );
     try {
-      await ps.eval(ps.parse("$oops.i.did.it.again"));
+      await ps.eval(parse("$oops.i.did.it.again"));
       throw new Error("expected block to throw, but it did not");
     } catch (error) {
       expect(error.name).toEqual("ReferenceError");
     }
   });
   it("errors if a derefenence does not return a PSValue", async () => {
-    let ps = createPlatformScript(map({
-      "oops": external(
-        { wrong: "type" },
-        //@ts-expect-error situation could happen if you are using JavaScript...
-        () => ({ type: "WAT!!", value: "hi" }),
-      ),
-    }));
+    let ps = createPlatformScript(() =>
+      map({
+        "oops": external(
+          { wrong: "type" },
+          //@ts-expect-error situation could happen if you are using JavaScript...
+          () => ({ type: "WAT!!", value: "hi" }),
+        ),
+      })
+    );
 
     try {
-      await ps.eval(ps.parse("$oops.wrong"));
+      await ps.eval(parse("$oops.wrong"));
       throw new Error("expected block to throw, but it did not");
     } catch (error) {
       expect(error.message).toMatch(

--- a/test/fn.test.ts
+++ b/test/fn.test.ts
@@ -4,15 +4,11 @@ import * as ps from "../mod.ts";
 describe("fn", () => {
   it("can be called directly", async () => {
     let interp = ps.createPlatformScript();
-    let program = interp.parse("$(thing): Hello %($thing)!");
+    let program = ps.parse("$(thing): Hello %($thing)!");
     let fn = await interp.eval(program);
     assert(fn.type === "fn");
     expect(
-      (await interp.call(fn, {
-        arg: ps.string("World"),
-        rest: ps.map({}),
-        env: ps.createYSEnv(),
-      })).value,
+      (await interp.call(fn, ps.string("World"))).value,
     ).toEqual("Hello World!");
   });
 });

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -2,11 +2,11 @@ export * from "https://deno.land/std@0.145.0/testing/bdd.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.9/mod.ts";
 export * from "https://deno.land/std@0.165.0/testing/asserts.ts";
 
-import { createPlatformScript, js2ps, ps2js, PSMap } from "../mod.ts";
+import { createPlatformScript, js2ps, parse, ps2js, PSMap } from "../mod.ts";
 
 export function evaluate(source: string, scope?: PSMap) {
   let ps = createPlatformScript();
-  let value = ps.parse(source, "script");
+  let value = parse(source, "script");
   return ps.eval(value, scope);
 }
 

--- a/types.ts
+++ b/types.ts
@@ -3,7 +3,7 @@ import { Operation, YAMLNode } from "./deps.ts";
 
 export interface PSEnv {
   eval(value: PSValue, scope?: PSMap): Operation<PSValue>;
-  call(fn: PSFn, funcall: PSFnCall): Operation<PSValue>;
+  call(fn: PSFn, arg: PSValue, options?: PSMap): Operation<PSValue>;
 }
 
 export interface PSModule {


### PR DESCRIPTION
## Motivation
low level environment operations such as `eval`, `load`, and `call` are all expressed as Effection operations, which means that we need a `run` function to be able to evaluate them. However, we want to make sure that the run function is scoped to the platform script interpreter because we want all operations to be halted when the interpreter is destroyed, so we can't just use raw Effection `run()`.

Futhermore, the global objects need to be able to access this enviroment in which they are running, which gives us a chicken and the egg problem because we require the global scope to be defined before we can create the interpreter in which it will be running.

## Approach
This changes the globals argument to an interpreter into a function that accepts an interpreter and returns the global arguments.

Also, to keep the interpreter clean, we remove the `parse` method since it doesn't really have anything to do with interpreting.