### PR TITLE
Compute current and next versions based on impact notes

### DIFF
--- a/.github/workflows/shipit.yml
+++ b/.github/workflows/shipit.yml
@@ -1,0 +1,22 @@
+name: tag releases
+on:
+  push:
+    branches: [main]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name:
+        run: |
+          deno task rel:shipit

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -1,0 +1,49 @@
+name: create release request
+on:
+  push:
+    branches: [main]
+jobs:
+  versions:
+    runs-on: ubuntu-latest
+
+    outputs:
+      current: ${{ steps.versions.outputs.current }}
+      next: ${{ steps.versions.outputs.current }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - id: versions
+        run: |
+          deno task rel:init
+          echo "current=$(deno task rel:current platformscript --pre=alpha)" >> $GITHUB_OUTPUT
+          echo "next=$(deno task rel:next platformscript --pre=alpha)" >> $GITHUB_OUTPUT
+
+      - name: prepare
+        if: steps.versions.outputs.next != steps.versions.outputs.current
+        run: |
+          deno task rel:impact platformscript --pre=alpha | deno task changelog-entry $(deno task rel:next platformscript --pre=alpha) | cat - Changelog.md > Changelog.next.md
+          mv Changelog.next.md Changelog.md
+          deno task rel:signoff platformscript --pre=alpha --message "Prepare platformscript ${{ steps.versions.outputs.next }}"
+          deno task rel:push
+
+      - name: create release request
+        if: steps.versions.outputs.next != steps.versions.outputs.current
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+          committer: Frontside Jack <jack@frontside.com>
+          author: Frontside Jack <jack@frontside.com>
+          branch: release/latest
+          base: main
+          title: Release PlatformScript ${{ steps.versions.outputs.next }}
+          body: |
+            TODO: say something smart about this release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,3 @@
+## 0.0.0
+
+- End of read, beginning of history

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,16 @@
 {
   "tasks": {
     "test": "deno test --allow-read --allow-net",
-    "build:npm": "deno run -A tasks/build-npm.ts"
+    "build:npm": "deno run -A tasks/build-npm.ts",
+    "changelog-entry": "deno run -A tasks/changelog-entry.ts",
+
+    "rel:init": "deno run -A tasks/rel/cmd/init.ts",
+    "rel:current": "deno run -A tasks/rel/cmd/current.ts",
+    "rel:next": "deno run -A tasks/rel/cmd/next.ts",
+    "rel:impact": "deno run -A tasks/rel/cmd/impact.ts",
+    "rel:signoff": "deno run -A tasks/rel/cmd/signoff.ts",
+    "rel:shipit": "deno run -A tasks/rel/cmd/shipit.ts",
+    "rel:push": "deno run -A tasks/rel/cmd/push.ts"
   },
   "lint": {
     "rules": {

--- a/tasks/changelog-entry.ts
+++ b/tasks/changelog-entry.ts
@@ -1,0 +1,33 @@
+import * as yaml from "npm:yaml";
+import { parse } from "https://deno.land/std@0.165.0/flags/mod.ts";
+import { readAll } from "https://deno.land/std@0.167.0/streams/read_all.ts";
+
+const flags = parse(Deno.args);
+
+const [version] = flags._;
+
+if (!version) {
+  throw new TypeError(`call update changelog with a version`);
+}
+
+let stdin = new TextDecoder().decode(await readAll(Deno.stdin));
+
+let docs = yaml.parseAllDocuments(stdin);
+
+let title = `## ${version}`;
+
+const entries = docs.map((doc: YAMLDoc) => {
+  let { summary } = doc.toJSON();
+  return `- ${summary}`;
+});
+
+await Deno.stdout.write(new TextEncoder().encode(`${title}
+
+${entries.join("\n")}
+
+`));
+
+interface YAMLDoc {
+  //deno-lint-ignore no-explicit-any
+  toJSON(): any;
+}

--- a/tasks/rel/cmd/current.ts
+++ b/tasks/rel/cmd/current.ts
@@ -1,0 +1,10 @@
+import { parse } from "https://deno.land/std@0.165.0/flags/mod.ts";
+import * as releases from "../releases.ts";
+
+const flags = parse(Deno.args, {
+  "string": ["pre"],
+});
+
+const { version } = await releases.current(String(flags._[0]), flags.pre);
+
+Deno.stdout.write(new TextEncoder().encode(`${version}\n`));

--- a/tasks/rel/cmd/fetch.ts
+++ b/tasks/rel/cmd/fetch.ts
@@ -1,0 +1,12 @@
+import { parse } from "../deps.ts";
+import { sh } from "../exec.ts";
+
+const flags = parse(Deno.args);
+
+let [remote] = flags._;
+
+if (!remote) {
+  throw new Error("must specify a remote to `rel fetch`");
+}
+
+await sh(`git fetch ${remote} refs/notes/*:refs/notes/*`);

--- a/tasks/rel/cmd/impact.ts
+++ b/tasks/rel/cmd/impact.ts
@@ -1,0 +1,27 @@
+import { parse, yaml } from "../deps.ts";
+import * as releases from "../releases.ts";
+import * as lineages from "../lineages.ts";
+import { since } from "../impact.ts";
+
+const flags = parse(Deno.args, {
+  "string": ["pre"],
+});
+
+const [lineageName] = flags._;
+const lineage = lineages.construct(String(lineageName));
+
+const current = await releases.current(lineage, flags.pre);
+
+let separator = () => Promise.resolve();
+
+const encoder = new TextEncoder();
+
+for await (let impact of since(lineages.construct(lineage), current)) {
+  await separator();
+  separator = async () => {
+    await Deno.stdout.write(encoder.encode("---\n"));
+  };
+  let { lineage: _, ...rest } = impact;
+  let text = `${yaml.stringify(rest, null, 2)}`;
+  await Deno.stdout.write(encoder.encode(text));
+}

--- a/tasks/rel/cmd/init.ts
+++ b/tasks/rel/cmd/init.ts
@@ -1,0 +1,14 @@
+import { sh } from "../exec.ts";
+
+try {
+  await sh("git config notes.rewriteRef refs/notes/*");
+  await sh("git config notes.displayRef refs/notes/*");
+  await sh("git config remote.origin.push +refs/notes/*:refs/notes/*");
+  await sh("git fetch origin refs/notes/*:refs/notes/*");
+} catch (error) {
+  if (error.name === "ShellError") {
+    console.error(error.message);
+  } else {
+    throw error;
+  }
+}

--- a/tasks/rel/cmd/next.ts
+++ b/tasks/rel/cmd/next.ts
@@ -1,0 +1,11 @@
+import { parse } from "https://deno.land/std@0.165.0/flags/mod.ts";
+import * as releases from "../releases.ts";
+
+const flags = parse(Deno.args, {
+  "string": ["pre"],
+});
+const [lineage] = flags._;
+
+const { version } = await releases.next(String(lineage), flags.pre);
+
+Deno.stdout.write(new TextEncoder().encode(`${version}\n`));

--- a/tasks/rel/cmd/push.ts
+++ b/tasks/rel/cmd/push.ts
@@ -1,0 +1,12 @@
+import { parse } from "../deps.ts";
+import { sh } from "../exec.ts";
+
+const flags = parse(Deno.args);
+
+let [remote] = flags._;
+
+if (!remote) {
+  throw new Error("must specify a remote to `rel push`");
+}
+
+await sh(`git push ${remote} refs/notes/*:refs/notes/*`);

--- a/tasks/rel/cmd/shipit.ts
+++ b/tasks/rel/cmd/shipit.ts
@@ -1,0 +1,33 @@
+import { parse, yaml } from "../deps.ts";
+import { sh } from "../exec.ts";
+import * as $notes from "../notes.ts";
+
+const flags = parse(Deno.args, {
+  "boolean": "dry-run",
+});
+
+const dryRun = flags["dry-run"] ?? false;
+
+for await (let note of $notes.all("shipit")) {
+  let releases = yaml.parse(note.content);
+  for (let tag of Object.values(releases) as string[]) {
+    if (dryRun) {
+      console.log(`[DRY] git tag ${tag} ${note.targetId}`);
+    } else {
+      await sh(["git", "tag", tag, note.targetId]);
+    }
+  }
+}
+
+const cleanup = [
+  "git push origin :refs/notes/shipit",
+  "git push origin --tags",
+];
+
+if (!dryRun) {
+  for (let cmd of cleanup) {
+    await sh(cmd);
+  }
+} else {
+  console.log(cleanup.map((cmd) => `[DRY] ${cmd}`).join("\n"));
+}

--- a/tasks/rel/cmd/signoff.ts
+++ b/tasks/rel/cmd/signoff.ts
@@ -1,0 +1,36 @@
+import { parse, yaml } from "../deps.ts";
+import * as $releases from "../releases.ts";
+import * as $notes from "../notes.ts";
+
+const flags = parse(Deno.args, {
+  "string": ["message", "pre"],
+});
+
+let [lineage] = flags._;
+
+if (!lineage) {
+  throw new Error(`prepare requires lineage`);
+}
+
+if (!flags.message) {
+  throw new Error(`prepare requires message`);
+}
+
+let prerelease = flags.pre;
+
+let current = await $releases.current(String(lineage), prerelease);
+
+let next = await $releases.next(String(lineage), prerelease);
+
+if (!$releases.eq(current, next)) {
+  console.log(`Signoff: ${next.lineage}@${next.version}`);
+  await $notes.upsert("shipit", (content) => {
+    let current = content ? yaml.parse(content) : {};
+    return yaml.stringify({
+      ...current,
+      [lineage]: next.tag,
+    });
+  });
+} else {
+  console.warn("Nothing to sign off.");
+}

--- a/tasks/rel/deps.ts
+++ b/tasks/rel/deps.ts
@@ -1,0 +1,7 @@
+export { parse } from "https://deno.land/std@0.165.0/flags/mod.ts";
+export { assert } from "https://deno.land/std@0.165.0/testing/asserts.ts";
+export { join } from "https://deno.land/std@0.167.0/path/mod.ts";
+export * as yaml from "npm:yaml";
+export * as semver from "https://deno.land/std@0.165.0/semver/mod.ts";
+export { basename } from "https://deno.land/std@0.167.0/path/mod.ts";
+export type { SemVer } from "https://deno.land/std@0.165.0/semver/mod.ts";

--- a/tasks/rel/exec.ts
+++ b/tasks/rel/exec.ts
@@ -1,0 +1,54 @@
+export interface ExecResult {
+  status: Deno.ProcessStatus;
+  stdout: string;
+  stderr: string;
+}
+
+export async function exec(cmd: string[]): Promise<string> {
+  let result = await execSafe(cmd);
+  if (result.status.success) {
+    return result.stdout;
+  } else {
+    let message = result.stdout.trim()
+      ? `${result.stdout}\n${result.stderr}`
+      : result.stderr;
+    let error = new Error(message);
+    error.name = "ExecError";
+    throw error;
+  }
+}
+
+export async function execSafe(cmd: string[]) {
+  let p = Deno.run({
+    cmd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  try {
+    let [status, stdout, stderr] = await Promise.all([
+      p.status(),
+      p.output(),
+      p.stderrOutput(),
+    ]);
+    let decoder = new TextDecoder();
+    return {
+      status,
+      stdout: decoder.decode(stdout),
+      stderr: decoder.decode(stderr),
+    };
+  } finally {
+    p.close();
+  }
+}
+
+export async function sh(cmdSpec: string | string[]): Promise<void> {
+  let encoder = new TextEncoder();
+  let cmd = Array.isArray(cmdSpec) ? cmdSpec : cmdSpec.split(/s+/);
+  let str = Array.isArray(cmdSpec) ? cmdSpec.join(" ") : cmdSpec;
+  Deno.stdout.write(encoder.encode(`${str}\n`));
+
+  let result = await exec(cmd);
+
+  Deno.stdout.write(encoder.encode(result));
+}

--- a/tasks/rel/git.ts
+++ b/tasks/rel/git.ts
@@ -1,0 +1,45 @@
+import type { Commit } from "./types.ts";
+import { join } from "./deps.ts";
+import { exec } from "./exec.ts";
+
+export async function currentId(): Promise<string> {
+  return (await exec(["git", "rev-parse", "HEAD"])).trim();
+}
+
+export async function toplevel(path?: string): Promise<string> {
+  let top = await exec(["git", "rev-parse", "--show-toplevel"]);
+  return path ? join(top, path) : top;
+}
+
+export async function* history(): AsyncGenerator<Commit> {
+  const pageSize = 50;
+  let last: Commit | void = void 0;
+  let records = 0;
+  do {
+    records = 0;
+    let head: string[] = last ? [last.id, "--skip", "1"] : [];
+    let cmd = ["git", "log"].concat(head).concat([
+      "-n",
+      `${pageSize}`,
+      "--format=%h%d %s",
+    ]);
+    let text = await exec(cmd);
+
+    for (let line of text.split("\n")) {
+      let match = line.match(/^([0-9a-f]+)\s(\((.+?)\))?\s?(.*)$/);
+      if (match) {
+        records++;
+        let id = match[1];
+        let refline = match[3];
+        let summary = match[4];
+        let refs = refline ? refline.split(", ") : [];
+        let tags = refs.flatMap((ref) => {
+          let tagmatch = ref.match(/^tag: (.+)$/);
+          return tagmatch ? [tagmatch[1]] : [];
+        });
+
+        yield last = { id, summary, refs, tags, line };
+      }
+    }
+  } while (records >= pageSize);
+}

--- a/tasks/rel/impact.ts
+++ b/tasks/rel/impact.ts
@@ -1,0 +1,49 @@
+import type { Commit, Impact, Lineage, Release } from "./types.ts";
+
+import { yaml } from "./deps.ts";
+import * as git from "./git.ts";
+import * as $notes from "./notes.ts";
+
+//returns if the level of impact of `b` is more than the impact of `a`
+export function gt(a: Impact, b: Impact) {
+  if (a.level === "major") {
+    return false;
+  } else if (a.level === "minor") {
+    return b.level === "major";
+  } else {
+    return b.level !== "patch";
+  }
+}
+
+export async function on(
+  lineage: Lineage,
+  commit: Commit,
+): Promise<Impact | void> {
+  let note = await $notes.read(lineage.ref, commit.id);
+  if (note) {
+    let { impact } = yaml.parse(note.content);
+    let level: Impact["level"] = impact;
+    let result = {
+      lineage,
+      level,
+      summary: commit.summary,
+    };
+
+    return result;
+  }
+}
+
+export async function* since(
+  lineage: Lineage,
+  release: Release,
+): AsyncGenerator<Impact> {
+  for await (let commit of git.history()) {
+    if (commit.tags.includes(release.tag)) {
+      break;
+    }
+    let impact = await on(lineage, commit);
+    if (impact) {
+      yield impact;
+    }
+  }
+}

--- a/tasks/rel/lineages.ts
+++ b/tasks/rel/lineages.ts
@@ -1,0 +1,70 @@
+import type { Idempotent, Lineage } from "./types.ts";
+import { basename } from "./deps.ts";
+
+export async function create(name: string): Promise<Idempotent<Lineage>> {
+  let filename = ".git/refs/notes/${name}.lineage";
+  let value = construct(name);
+  try {
+    await Deno.stat(filename);
+    return {
+      redundant: true,
+      value,
+    };
+  } catch (_) {
+    await Deno.writeTextFile(filename, "", { append: true, create: true });
+    return {
+      redundant: false,
+      value,
+    };
+  }
+}
+
+export async function remove(
+  name: string | Lineage,
+): Promise<Idempotent<void>> {
+  let filename = `.git/refs/notes/${construct(name).name}.lineage`;
+  let value = void 0;
+  try {
+    await Deno.stat(filename);
+  } catch (_) {
+    return {
+      redundant: true,
+      value,
+    };
+  }
+  await Deno.remove(filename);
+  return {
+    redundant: false,
+    value,
+  };
+}
+
+export async function* all(): AsyncGenerator<Lineage> {
+  for await (let entry of Deno.readDir("./.git/refs/notes")) {
+    let filename = basename(entry.name);
+    let match = filename.match(/(.+)\.lineage$/);
+    if (match) {
+      let name = match[1];
+      yield construct(name);
+    }
+  }
+}
+
+export function construct(nameOrLineage: string | Lineage): Lineage {
+  let name = typeof nameOrLineage === "string"
+    ? nameOrLineage
+    : nameOrLineage.name;
+  return {
+    name,
+    get ref() {
+      return `${name}.lineage`;
+    },
+    get prefix() {
+      return `${name}-v`;
+    },
+  };
+}
+
+export function eq(a: Lineage, b: Lineage): boolean {
+  return a.name === b.name;
+}

--- a/tasks/rel/notes.ts
+++ b/tasks/rel/notes.ts
@@ -1,0 +1,72 @@
+import type { Note } from "./types.ts";
+import { assert } from "./deps.ts";
+import { exec, execSafe } from "./exec.ts";
+import * as $git from "./git.ts";
+
+export type Upsert = (content?: string) => string;
+
+export async function upsert(ref: string, fn: Upsert): Promise<void> {
+  let current = await read(ref);
+  let next = fn(current ? current.content : void 0);
+  await write(ref, next);
+}
+
+export async function read(
+  ref: string,
+  commitId?: string,
+): Promise<Note | void> {
+  let targetId = commitId ? commitId : await $git.currentId();
+  let cmd = ["git", "notes", `--ref=${ref}`, "show", targetId];
+  let result = await execSafe(cmd);
+
+  if (!result.status.success) {
+    let { stderr } = result;
+    if (stderr.match(/no note found/)) {
+      return void 0;
+    } else {
+      let error = new Error(stderr);
+      error.name = "GitError";
+      throw error;
+    }
+  } else {
+    return { ref, targetId, content: result.stdout };
+  }
+}
+
+export async function write(
+  ref: string,
+  content: string,
+  commitId?: string,
+): Promise<Note> {
+  let tmpfile = await Deno.makeTempFile();
+  let targetId = commitId ? commitId : await $git.currentId();
+  try {
+    await Deno.writeTextFile(tmpfile, content, { append: false, create: true });
+    await exec([
+      "git",
+      "notes",
+      `--ref=${ref}`,
+      "add",
+      "-f",
+      `--file=${tmpfile}`,
+      targetId,
+    ]);
+    return { ref, targetId, content };
+  } finally {
+    await Deno.remove(tmpfile);
+  }
+}
+
+export async function* all(ref: string): AsyncGenerator<Note> {
+  let list = await exec(["git", "notes", `--ref=${ref}`]);
+  if (list) {
+    for (let line of list.split("\n")) {
+      if (line) {
+        let [id, targetId] = line.split(/\s+/);
+        let note = await read(ref, targetId);
+        assert(!!note, `ref for note ${id} -> ${targetId} but cannot read it!`);
+        yield note;
+      }
+    }
+  }
+}

--- a/tasks/rel/ops.ts
+++ b/tasks/rel/ops.ts
@@ -1,0 +1,56 @@
+export interface Predicate<T> {
+  (value: T): Promise<boolean>;
+}
+
+export async function* filter<T>(
+  items: AsyncGenerator<T>,
+  predicate: Predicate<T>,
+): AsyncGenerator<T> {
+  for await (let item of items) {
+    if (await predicate(item)) {
+      yield item;
+    }
+  }
+}
+
+export async function* until<T>(
+  items: AsyncGenerator<T>,
+  limit: Predicate<T>,
+): AsyncGenerator<T> {
+  for await (let item of items) {
+    if (await limit(item)) {
+      break;
+    } else {
+      yield item;
+    }
+  }
+}
+
+export async function first<T>(items: AsyncGenerator<T>): Promise<T | void> {
+  for await (let item of items) {
+    return item;
+  }
+}
+
+export function find<T>(
+  items: AsyncGenerator<T>,
+  predicate: (t: T) => Promise<boolean>,
+): Promise<T | void> {
+  return first(filter(items, predicate));
+}
+
+export async function reduce<T, TResult>(
+  items: AsyncGenerator<T>,
+  initial: TResult,
+  reducer: (result: TResult, item: T) => Promise<TResult>,
+): Promise<TResult> {
+  let result = initial;
+  for await (let item of items) {
+    result = await reducer(result, item);
+  }
+  return result;
+}
+
+export function sizeOf(items: AsyncGenerator<unknown>): Promise<number> {
+  return reduce(items, 0, (sum) => Promise.resolve(sum + 1));
+}

--- a/tasks/rel/releases.ts
+++ b/tasks/rel/releases.ts
@@ -1,0 +1,139 @@
+import type { Impact, Lineage, Release } from "./types.ts";
+
+import { SemVer, semver } from "./deps.ts";
+import { find, reduce, sizeOf } from "./ops.ts";
+import * as git from "./git.ts";
+import * as impact from "./impact.ts";
+import * as lineages from "./lineages.ts";
+
+export async function* since(release: Release): AsyncGenerator<Release> {
+  for await (let rel of all(release.lineage)) {
+    if (eq(rel, release)) {
+      break;
+    } else {
+      yield rel;
+    }
+  }
+}
+
+export async function* all(lineage: Lineage): AsyncGenerator<Release> {
+  let exists = await find(
+    lineages.all(),
+    (lin) => Promise.resolve(lineages.eq(lineage, lin)),
+  );
+  if (!exists) {
+    console.dir({ lineage });
+    let error = new Error(lineage.name);
+    error.name = "NoSuchLineageErro";
+    throw error;
+  }
+
+  let { prefix } = lineage;
+  for await (let commit of git.history()) {
+    for (let tag of commit.tags) {
+      if (tag.startsWith(lineage.prefix)) {
+        let version = semver.parse(tag.replace(prefix, ""));
+        if (version) {
+          yield construct(lineage, version);
+        }
+      }
+    }
+  }
+}
+
+export async function basis(lineage: Lineage): Promise<Release> {
+  let existing = await find(
+    all(lineage),
+    ({ version }) => Promise.resolve(version.prerelease.length === 0),
+  );
+
+  return existing ?? construct(lineage, semver.parse("0.0.0") as SemVer);
+}
+
+export async function current(
+  lineageSpec: string | Lineage,
+  prerelease?: string,
+): Promise<Release> {
+  let lineage = lineages.construct(lineageSpec);
+  let min = await basis(lineage);
+
+  if (prerelease) {
+    let greatest = await reduce(
+      impact.since(lineage, min),
+      null as Impact | null,
+      (greatest, stmt) => {
+        return Promise.resolve(
+          !greatest || impact.gt(greatest, stmt) ? stmt : greatest,
+        );
+      },
+    );
+
+    if (greatest) {
+      let premin = min.version.increment(`pre${greatest.level}`, prerelease);
+      let premax = await find(since(min), (release) => {
+        let [id] = release.version.prerelease as [string, number];
+        return Promise.resolve(
+          id === prerelease && semver.gt(release.version, premin),
+        );
+      });
+      return premax ?? construct(lineage, premin);
+    } else {
+      return min;
+    }
+  } else {
+    return min;
+  }
+}
+
+export async function next(
+  lineageSpec: string | Lineage,
+  prerelease?: string,
+): Promise<Release> {
+  let lineage = lineages.construct(lineageSpec);
+
+  let current = await basis(lineage);
+
+  let greatest = await reduce(
+    impact.since(lineage, current),
+    null as Impact | null,
+    (greatest, stmt) => {
+      return Promise.resolve(
+        !greatest || impact.gt(greatest, stmt) ? stmt : greatest,
+      );
+    },
+  );
+
+  if (greatest) {
+    if (prerelease) {
+      let min = current.version.increment(`pre${greatest.level}`, prerelease);
+      let max = await find(since(current), (release) => {
+        let [id] = release.version.prerelease as [string, number];
+        return Promise.resolve(
+          id === prerelease && semver.gt(release.version, min),
+        );
+      });
+      if (max) {
+        if (await sizeOf(impact.since(lineage, max)) > 0) {
+          return construct(lineage, max.version.increment("prerelease"));
+        } else {
+          return max;
+        }
+      } else {
+        return construct(lineage, min);
+      }
+    } else {
+      let version = current.version.increment(greatest.level);
+      return construct(lineage, version);
+    }
+  } else {
+    return current;
+  }
+}
+
+export function eq(a: Release, b: Release): boolean {
+  return a.tag === b.tag;
+}
+
+export function construct(lineage: Lineage, version: SemVer): Release {
+  return { lineage, version, tag: `${lineage.prefix}${version}` };
+}

--- a/tasks/rel/types.ts
+++ b/tasks/rel/types.ts
@@ -1,0 +1,41 @@
+import * as semver from "./deps.ts";
+
+export type SemVer = semver.SemVer;
+
+export interface Lineage {
+  name: string;
+  ref: string;
+  prefix: string;
+}
+
+export interface Impact {
+  level: "major" | "minor" | "patch";
+  lineage: Lineage;
+  summary: string;
+  details?: string;
+}
+
+export interface Release {
+  lineage: Lineage;
+  version: SemVer;
+  tag: string;
+}
+
+export interface Note {
+  ref: string;
+  targetId: string;
+  content: string;
+}
+
+export interface Commit {
+  id: string;
+  summary: string;
+  refs: string[];
+  tags: string[];
+  line: string;
+}
+
+export interface Idempotent<T> {
+  redundant: boolean;
+  value: T;
+}


### PR DESCRIPTION
## Motivation
To have the power to compute the version number of the next release should it be cut at this very moment.

## Approach
In order to automatically compute the current version, should a release be cut at any moment, we need to know what the last major version released was in the history of the current commit. This version from which releases are computed is called the "basis"

This adds a task `rel:current` which walks backwards along the git history looking for primary release tags. A primary release tag is one whose  format `PREFX-vmajor.minor.patch` and does not contain any pre-release modifiers.

Because this is a monorepo and there can be multiple release lineages you can pass a name as an argument. So, for example, in this repository, we have two lineages: `platformscript` and `platformscript-website`.

If there is no basis, we use `0.0.0`. If there is no lineage specified, we use the default of empty string, which is appropriate for single-project repositories.

These below examples are illustrative, but don't correpsond to the actual versions in the repository.

```text
$ deno task rel:current platformscript
0.0.1
```

```text
$ deno task rel:current
0.0.0
```

```text
$ deno task rel:current platformscript-website
0.0.221
```

To find the next version based on the impact contained in git-notes, use the `rel:next` task which calucates what the next version would need to be if released today. So, if there are only minor changes on the current branch:

```text
$ deno task rel:current platformscript
0.0.0
$ deno task rel:next platformscript
0.1.0
```

but if there are major changes:

```text
$ deno task rel:next platformscript
1.0.0
```

The `rel:next` task accepts a "--pre" flag which let's you specify a pre-release identifier and it will create a pre-release flag which will take into account all previous pre-releases. Let's say for example, that you currently are on `platformscript-v0.1.0` and you have major changes.

```text
$ deno task rel:next platformscript
1.0.0
$ deno task rel:next platformscript --pre=alpha
1.0.0-alpha.0
```
The difference is that i there are existing `1.0.0-alpha.x` tags, it will start from the latest. Let's assume that the latest pre-release for 1.0.0 is `alpha.6` If there are any impact notes after `1.0.0-alpha.6` it will just increment the prerelease number:

```text
$ deno task rel:next platformscript --pre=alpha
1.0.0-alpha.7
```
In order to work with notes locally, you will need to run the `rel:init` task:

```text
Task rel:init deno run -A tasks/rel/init.ts
git config notes.rewriteRef refs/notes/*
git config notes.displayRef refs/notes/release
git config remote.origin.push +refs/notes/*:refs/notes/*
```