### PR TITLE
Add ability to evaluate a value as a PlatformScript module.

### DIFF
--- a/platformscript.ts
+++ b/platformscript.ts
@@ -2,7 +2,7 @@ import type { PSEnv, PSFn, PSMap, PSModule, PSValue } from "./types.ts";
 import type { Operation, Task } from "./deps.ts";
 import { createYSEnv, global } from "./evaluate.ts";
 import { concat } from "./psmap.ts";
-import { load } from "./load.ts";
+import { load, moduleEval } from "./load.ts";
 import { map } from "./data.ts";
 import { run as $run } from "./deps.ts";
 
@@ -10,6 +10,7 @@ export interface PlatformScript {
   run<T>(block: (env: PSEnv) => Operation<T>): Task<T>;
   call(fn: PSFn, arg: PSValue, options?: PSMap): Task<PSValue>;
   eval(value: PSValue, bindings?: PSMap): Task<PSValue>;
+  moduleEval(value: PSValue, url: string | URL): Task<PSModule>;
   load(url: string | URL, base?: string): Task<PSModule>;
 }
 
@@ -32,6 +33,9 @@ export function createPlatformScript(
     },
     eval(value, bindings) {
       return run((env) => env.eval(value, bindings));
+    },
+    moduleEval(value, url) {
+      return run((env) => moduleEval({ body: value, location: url, env }));
     },
     load(location, base) {
       return run((env) => load({ location, base, env }));


### PR DESCRIPTION
## Motivation
Sometimes we want to be able to treat a snippet of code as a fully formed module that can depend on other modules and define symbols.

There is a bit of a risk in the sense of what do you do if you have two different virtual modules that have the same URL? This should probably be an error.

## Approach
This adds a `moduleEval` operation to PlatformScript to treat any PlatformScript value as a module.

### Alternate Designs

We can in the future just make `$import` a function that is defined everywhere and the result is that it just returns a module. This can be explored later.