### PR TITLE
Explicitly pass all commands as an array to `sh()` on init

### DIFF
--- a/.github/workflows/shipit.yml
+++ b/.github/workflows/shipit.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
 
       - name: setup deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
 
       - name: setup deno
         uses: denoland/setup-deno@v1

--- a/tasks/rel/cmd/init.ts
+++ b/tasks/rel/cmd/init.ts
@@ -1,10 +1,9 @@
 import { sh } from "../exec.ts";
 
 try {
-  await sh("git config notes.rewriteRef refs/notes/*");
-  await sh("git config notes.displayRef refs/notes/*");
-  await sh("git config remote.origin.push +refs/notes/*:refs/notes/*");
-  await sh("git fetch origin refs/notes/*:refs/notes/*");
+  await sh(["git", "config", "notes.rewriteRef", "refs/notes/*"]);
+  await sh(["git", "config", "notes.displayRef", "refs/notes/*"]);
+  await sh(["git", "fetch", "-f", "origin", "refs/notes/*:refs/notes/*"]);
 } catch (error) {
   if (error.name === "ShellError") {
     console.error(error.message);


### PR DESCRIPTION
## Motivation

There was a problem where a dirglob was not being interpreted properly because of the way we were splitting a string. See https://github.com/thefrontside/platformscript/actions/runs/3634349693/jobs/6132343127

## Approach
Instead This just passess each elemen as a separat item that way there is no ambiguity in the way the shell parses it.