### PR TITLE
Get rid of command string commands and use arrays for shipit

### DIFF
--- a/tasks/rel/cmd/shipit.ts
+++ b/tasks/rel/cmd/shipit.ts
@@ -20,8 +20,8 @@ for await (let note of $notes.all("shipit")) {
 }
 
 const cleanup = [
-  "git push origin :refs/notes/shipit",
-  "git push origin --tags",
+  ["git", "push", "origin", ":refs/notes/shipit"],
+  ["git", "push", "origin", "--tags"],
 ];
 
 if (!dryRun) {
@@ -29,5 +29,5 @@ if (!dryRun) {
     await sh(cmd);
   }
 } else {
-  console.log(cleanup.map((cmd) => `[DRY] ${cmd}`).join("\n"));
+  console.log(cleanup.map((cmd) => `[DRY] ${cmd.join(" ")}`).join("\n"));
 }


### PR DESCRIPTION
## Motivation
]Again, we were having an issue where the short form single-string command was not encoding arguments properly.

## Approach

Just take the long way around and do the not-so-cute thing that works!
