### PR TITLE
Add `method(param):`  syntax for quickly defining a map of functions

### DIFF
--- a/test/fn.test.ts
+++ b/test/fn.test.ts
@@ -52,4 +52,23 @@ $do: { $say: Hello }
     let interp = ps.createPlatformScript();
     await interp.moduleEval(program, import.meta.url);
   });
+
+  it("can parse method syntax", async () => {
+    let map = ps.parse(`{x: 5, y(x): $x}`);
+    assert(map.type === "map");
+    let x = lookup("x", map);
+    assert(x.type === "just");
+    expect(x.value.value).toEqual(5);
+
+    let y = lookup("y", map);
+    assert(y.type === "just");
+    assert(y.value.type === "fn");
+
+    let interp = ps.createPlatformScript();
+
+    expect(await interp.call(y.value, ps.string("Hello"))).toEqual({
+      type: "string",
+      value: "Hello",
+    });
+  });
 });


### PR DESCRIPTION
## Motivation

#32  part 2

## Approach

You can now define functions within a mapping. This operates at the syntax level, so when you actually parse a yaml script it substitutes the function values for the keys.