### PR TITLE
use `origin` as default remote when pushing notes

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -36,7 +36,7 @@ jobs:
           deno task rel:impact platformscript --pre=alpha | deno task changelog-entry $(deno task rel:next platformscript --pre=alpha) | cat - Changelog.md > Changelog.next.md
           mv Changelog.next.md Changelog.md
           deno task rel:signoff platformscript --pre=alpha --message "Prepare platformscript ${{ steps.versions.outputs.next }}"
-          deno task rel:push
+          deno task rel:push origin
 
       - name: create release request
         if: steps.versions.outputs.next != steps.versions.outputs.current

--- a/tasks/rel/cmd/push.ts
+++ b/tasks/rel/cmd/push.ts
@@ -5,8 +5,4 @@ const flags = parse(Deno.args);
 
 let [remote] = flags._;
 
-if (!remote) {
-  throw new Error("must specify a remote to `rel push`");
-}
-
-await sh(`git push ${remote} refs/notes/*:refs/notes/*`);
+await sh(`git push ${remote ?? "origin"} refs/notes/*:refs/notes/*`);


### PR DESCRIPTION
## Motivation

sign-off still broken because origin was not specified
## Approach

make remote optional, use "origin" by default
