### PR TITLE
fix git command that pushes notes.

### DIFF
--- a/tasks/rel/cmd/push.ts
+++ b/tasks/rel/cmd/push.ts
@@ -5,4 +5,9 @@ const flags = parse(Deno.args);
 
 let [remote] = flags._;
 
-await sh(`git push ${remote ?? "origin"} refs/notes/*:refs/notes/*`);
+await sh([
+  "git",
+  "push",
+  `${remote ?? "origin"}`,
+  "refs/notes/*:refs/notes/*`",
+]);


### PR DESCRIPTION
## Motivation

Trying to do shell parse for commands is a lost cause.

## Approach
Just use an array, every. darn. time.