### PR TITLE
fix scoping for native functions

### DIFF
--- a/evaluate.ts
+++ b/evaluate.ts
@@ -75,18 +75,7 @@ export function createYSEnv(parent = global): PSEnv {
         }
         return data.string(str);
       } else if (value.type === "fncall") {
-        let fn = value.value;
-        if (fn.value.type === "native") {
-          return yield* fn.value.call(value);
-        } else {
-          let arg = yield* env.eval(value.arg);
-          return yield* env.eval(
-            fn.value.body,
-            data.map({
-              [fn.param.name]: arg,
-            }),
-          );
-        }
+        return yield* env.call(value.value, value.arg, value.rest);
       } else if (value.type === "map") {
         let entries: [PSMapKey, PSValue][] = [];
         for (let [k, v] of value.value.entries()) {
@@ -120,6 +109,7 @@ export function createYSEnv(parent = global): PSEnv {
       }
     },
   };
+
   return env;
 }
 

--- a/test/fn.test.ts
+++ b/test/fn.test.ts
@@ -71,4 +71,24 @@ $do: { $say: Hello }
       value: "Hello",
     });
   });
+
+  it("can reference values from arguments to native functions", async () => {
+    let interp = ps.createPlatformScript(() =>
+      ps.map({
+        id: ps.fn(function* $id({ arg, env }) {
+          return yield* env.eval(arg);
+        }, { name: "x" }),
+      })
+    );
+
+    let program = ps.parse(`
+$let:
+  myid(x):
+    $id: $x
+$do:
+  $myid: hello world
+`);
+    let result = await interp.eval(program);
+    expect(result.value).toEqual("hello world");
+  });
 });


### PR DESCRIPTION
## Motivation

The environment of native functions only contained the lexical scope that was bound. However, an environment is augmented by a function parameter when its body is evaluated. We need to make sure that the environment passed to the native function contains this augmented scope rather than the just the scope when it was bound as a function call.

## Approach

Route all function calls through the same logic, which uses the environment currently in use and is guaranteed to have the function parameters in scope.