### PR TITLE
Allow calling fns that are referenced by a fn parameter

### DIFF
--- a/data.ts
+++ b/data.ts
@@ -2,7 +2,7 @@ import type {
   PSBoolean,
   PSExternal,
   PSFn,
-  PSFnCall,
+  PSFnCallContext,
   PSList,
   PSMap,
   PSNumber,
@@ -56,7 +56,7 @@ export function external(
 }
 
 export function fn(
-  call: (cxt: PSFnCall) => Operation<PSValue>,
+  call: (cxt: PSFnCallContext) => Operation<PSValue>,
   param: PSFn["param"],
 ): PSFn {
   return {

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -73,9 +73,6 @@ $do:
       expect(await eval2js(`{$let: {x: 5 }, $do: $x}`)).toEqual(5);
     });
 
-    it("allows binding expressions to appear afterwards", async () => {
-      expect(await eval2js(`{$do: $x, $let: { x: 5 }}`)).toEqual(5);
-    });
     it("evaluates an empty let binding as false", async () => {
       expect(await eval2js(`$let: {x: 5}`)).toEqual(false);
     });

--- a/test/fn.test.ts
+++ b/test/fn.test.ts
@@ -91,4 +91,19 @@ $do:
     let result = await interp.eval(program);
     expect(result.value).toEqual("hello world");
   });
+
+  it("can invoke a function that is accessible off a function parameter scope", async () => {
+    let program = ps.parse(`
+$let:
+  holder:
+    id(x): $x
+  hi(thing): { $thing.id: "hello" }
+$do: { $hi: $holder }
+`);
+    let interp = ps.createPlatformScript();
+    expect(await interp.eval(program)).toEqual({
+      type: "string",
+      value: "hello",
+    });
+  });
 });

--- a/types.ts
+++ b/types.ts
@@ -86,7 +86,7 @@ export interface PSFn {
   param: { name: string };
   value: {
     type: "native";
-    call(cxt: PSFnCall): Operation<PSValue>;
+    call(cxt: PSFnCallContext): Operation<PSValue>;
   } | {
     type: "platformscript";
     body: PSValue;
@@ -95,7 +95,13 @@ export interface PSFn {
 
 export interface PSFnCall {
   type: "fncall";
-  value: PSFn;
+  value: PSRef | PSFn;
+  arg: PSValue;
+  rest: PSMap;
+}
+
+export interface PSFnCallContext {
+  fn: PSFn;
   arg: PSValue;
   rest: PSMap;
   env: PSEnv;


### PR DESCRIPTION
## Motivation
When converting a map into a function call, we were requiring that the function be defined at the time of binding. this works module imports or global functions, but what if the function reference is introduced into a scope via a function parameter? We need to leave it as a reference and then look up the reference when we bind the function body before evaluation of the function.

## Approach
This changes the name of the `FnCall -> FnCallContext` and then the PSValue of type `fncall` records only the fact of the function call itself, and does not create an environment. This is better in that the `FNCall` is just data.

Note that this breaks the `$do/$let` statement... as you can now not introduce a `$let` statement after `$do`. You either need to but `$let` before, or not have it at all.