### PR TITLE
🐛Fix main layout which was converted to flex

### DIFF
--- a/www/components/main-page.tsx
+++ b/www/components/main-page.tsx
@@ -21,7 +21,7 @@ export function createMainPage<TProps extends MainPageProps = MainPageProps>(
         <Head>
           <base href={props.data.base} />
         </Head>
-        <div class="flex flex-col h-screen justify-between">
+        <div class="flex flex-col justify-between">
           <Header active={props.data.active} />
           <main class="h-full">
             <Component {...props} />


### PR DESCRIPTION
## Motivation
We changed the main layout to be a flex box, but it was still being marked as `h-screen`. This had the effect of putting the footer over the main content once you scroll past the fold.

## Approach
This removes that `h-screen` designation to set the flex box free and let it flow.


## Screenshots
![removing h-screen fixes footer location](https://user-images.githubusercontent.com/4205/213380918-984d8bee-dcee-4464-9700-82266ae45008.gif)
