### PR TITLE
fix playground layout

### DIFF
--- a/www/components/main-page.tsx
+++ b/www/components/main-page.tsx
@@ -21,9 +21,9 @@ export function createMainPage<TProps extends MainPageProps = MainPageProps>(
         <Head>
           <base href={props.data.base} />
         </Head>
-        <div class="flex flex-col justify-between">
-          <Header active={props.data.active} />
-          <main class="h-full">
+        <div class="h-screen flex flex-col">
+          <Header className="flex justify-between" active={props.data.active} />
+          <main style={{flexGrow: 1}}>
             <Component {...props} />
           </main>
           <Footer className="border(t-2 gray-200) bg-gray-100 h-32 flex flex-col gap-4 justify-center" />


### PR DESCRIPTION
## Motivation

The playground does not have any implicit height because it is set by the monaco editor. As a result, it is squnched between the header and footer.

## Approach

This adds the "flex-grow: 1" property to make it expand to fill up all the room left over in the middle of the flex box. That way, it will always fill the space between the header and the footer.

## Screenshots

![2023-01-24 12 26 59](https://user-images.githubusercontent.com/4205/214377607-c3e6b43b-b954-4d71-86ec-4b24c02ff739.gif)
