### PR TITLE
fix the signoff workflow

### DIFF
--- a/.github/workflows/shipit.yml
+++ b/.github/workflows/shipit.yml
@@ -22,3 +22,5 @@ jobs:
         run: |
           deno task rel:init
           deno task rel:shipit
+          git push origin 'refs/notes/*:refs/notes/*'
+          git push origin --tags

--- a/tasks/rel/cmd/shipit.ts
+++ b/tasks/rel/cmd/shipit.ts
@@ -1,6 +1,7 @@
-import { parse, yaml } from "../deps.ts";
+import { parse } from "../deps.ts";
 import { sh } from "../exec.ts";
-import * as $notes from "../notes.ts";
+
+import * as $signoffs from "../signoffs.ts";
 
 const flags = parse(Deno.args, {
   "boolean": "dry-run",
@@ -8,26 +9,15 @@ const flags = parse(Deno.args, {
 
 const dryRun = flags["dry-run"] ?? false;
 
-for await (let note of $notes.all("shipit")) {
-  let releases = yaml.parse(note.content);
-  for (let tag of Object.values(releases) as string[]) {
+for await (let signoff of $signoffs.untagged()) {
+  for (let tag of signoff.releases) {
     if (dryRun) {
-      console.log(`[DRY] git tag ${tag} ${note.targetId}`);
+      console.log(`[DRY] git tag ${tag} ${signoff.commitId}`);
     } else {
-      await sh(["git", "tag", tag, note.targetId]);
+      await sh(["git", "tag", tag, signoff.commitId]);
     }
   }
-}
-
-const cleanup = [
-  ["git", "push", "origin", ":refs/notes/shipit"],
-  ["git", "push", "origin", "--tags"],
-];
-
-if (!dryRun) {
-  for (let cmd of cleanup) {
-    await sh(cmd);
+  if (!dryRun) {
+    await $signoffs.complete(signoff);
   }
-} else {
-  console.log(cleanup.map((cmd) => `[DRY] ${cmd.join(" ")}`).join("\n"));
 }

--- a/tasks/rel/cmd/signoff.ts
+++ b/tasks/rel/cmd/signoff.ts
@@ -1,6 +1,6 @@
-import { parse, yaml } from "../deps.ts";
+import { parse } from "../deps.ts";
 import * as $releases from "../releases.ts";
-import * as $notes from "../notes.ts";
+import * as $signoffs from "../signoffs.ts";
 
 const flags = parse(Deno.args, {
   "string": ["pre"],
@@ -20,13 +20,8 @@ let next = await $releases.next(String(lineage), prerelease);
 
 if (!$releases.eq(current, next)) {
   console.log(`Signoff: ${next.lineage.name}@${next.version}`);
-  await $notes.upsert("shipit", (content) => {
-    let current = content ? yaml.parse(content) : {};
-    return yaml.stringify({
-      ...current,
-      [lineage]: next.tag,
-    });
-  });
+
+  await $signoffs.signoff(next);
 } else {
   console.warn("Nothing to sign off.");
 }

--- a/tasks/rel/notes.ts
+++ b/tasks/rel/notes.ts
@@ -5,10 +5,14 @@ import * as $git from "./git.ts";
 
 export type Upsert = (content?: string) => string;
 
-export async function upsert(ref: string, fn: Upsert): Promise<void> {
-  let current = await read(ref);
+export async function upsert(
+  ref: string,
+  fn: Upsert,
+  commitId?: string,
+): Promise<void> {
+  let current = await read(ref, commitId);
   let next = fn(current ? current.content : void 0);
-  await write(ref, next);
+  await write(ref, next, commitId);
 }
 
 export async function read(

--- a/tasks/rel/ops.ts
+++ b/tasks/rel/ops.ts
@@ -13,6 +13,15 @@ export async function* filter<T>(
   }
 }
 
+export async function* map<T, R>(
+  items: AsyncGenerator<T>,
+  fn: (value: T) => Promise<R>,
+): AsyncGenerator<R> {
+  for await (let item of items) {
+    yield await fn(item);
+  }
+}
+
 export async function* until<T>(
   items: AsyncGenerator<T>,
   limit: Predicate<T>,

--- a/tasks/rel/signoffs.ts
+++ b/tasks/rel/signoffs.ts
@@ -1,0 +1,45 @@
+import type { Release, Signoff } from "./types.ts";
+import * as $git from "./git.ts";
+import * as $notes from "./notes.ts";
+import { filter, map, until } from "./ops.ts";
+import { yaml } from "./deps.ts";
+
+export function untagged(): AsyncGenerator<Signoff> {
+  let signoffs = filter(
+    map($git.history(), async (commit) => {
+      let note = await $notes.read("signoffs", commit.id);
+      return note
+        ? {
+          ...yaml.parse(note.content),
+          commitId: commit.id,
+        } as Signoff
+        : null;
+    }),
+    (signoff) => Promise.resolve(!!signoff),
+  ) as AsyncGenerator<Signoff>;
+  return until(signoffs, (signoff) => Promise.resolve(!!signoff.taggedAt));
+}
+
+export async function signoff(release: Release): Promise<void> {
+  await $notes.upsert("signoffs", (content) => {
+    let current = content ? yaml.parse(content) : {
+      releases: [],
+    };
+    return yaml.stringify({
+      ...current,
+      releases: current.releases.concat(release.tag),
+    });
+  });
+}
+
+export async function complete(signoff: Signoff): Promise<void> {
+  await $notes.upsert("signoffs", (content) => {
+    let current = content ? yaml.parse(content) : {
+      releases: [],
+    };
+    return yaml.stringify({
+      ...current,
+      taggedAt: new Date().toISOString(),
+    });
+  }, signoff.commitId);
+}

--- a/tasks/rel/types.ts
+++ b/tasks/rel/types.ts
@@ -39,3 +39,9 @@ export interface Idempotent<T> {
   redundant: boolean;
   value: T;
 }
+
+export interface Signoff {
+  commitId: string;
+  releases: string[];
+  taggedAt?: string;
+}


### PR DESCRIPTION
## Motivation

It was trying to tag all releases that had signoff commits, not those that were in the current git history.

## Approach

Walk backwards until the last tagged signify to see if there are any releases pending.