### PR TITLE
Print

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -2,6 +2,7 @@ export * from "./types.ts";
 export * from "./convert.ts";
 export * from "./read.ts";
 export * from "./evaluate.ts";
+export * from "./print.ts";
 export * from "./load.ts";
 export * from "./platformscript.ts";
 export * from "./data.ts";

--- a/print.ts
+++ b/print.ts
@@ -1,0 +1,59 @@
+import type { PSString, PSValue } from "./types.ts";
+
+import { yaml } from "./deps.ts";
+import * as data from "./data.ts";
+import { isLiteral } from "./read.ts";
+
+export function print(value: PSValue): PSString {
+  let doc = new yaml.Document(toYAML(value));
+  return data.string(doc.toString().slice(0, -1));
+}
+
+function toYAML(value: PSValue): yaml.Node {
+  if (isLiteral(value)) {
+    return value.node;
+  }
+
+  switch (value.type) {
+    case "string":
+    case "number":
+    case "boolean":
+      return new yaml.Scalar(value.value);
+    case "list": {
+      let seq = new yaml.YAMLSeq();
+      for (let item of value.value) {
+        seq.add(toYAML(item));
+      }
+      return seq;
+    }
+    case "map": {
+      let map = new yaml.YAMLMap();
+      for (let [k, v] of value.value.entries()) {
+        map.add(new yaml.Pair(toYAML(k), toYAML(v)));
+      }
+      return map;
+    }
+    case "ref":
+    case "template":
+      return toYAML(value.value);
+    case "fn": {
+      let map = new yaml.YAMLMap();
+      if (value.value.type === "platformscript") {
+        map.add(
+          new yaml.Pair(toYAML(value.value.head), toYAML(value.value.body)),
+        );
+      } else {
+        let head = `(${value.param.name})=>`;
+        let body = "<[native fn]>";
+        map.add(new yaml.Pair(new yaml.Scalar(head), new yaml.Scalar(body)));
+      }
+      return map;
+    }
+    case "fncall":
+      return toYAML(value.source);
+    case "external":
+      return new yaml.Scalar("<[external]>");
+    default:
+      throw new Error(`FATAL: non exhaustive print() match.`);
+  }
+}

--- a/recognize.ts
+++ b/recognize.ts
@@ -59,6 +59,7 @@ export function recognize(value: PSValue): PSValue {
               type: "map",
               value: new Map(rest),
             },
+            source: value,
           };
         }
         return derive(value, {

--- a/test/print.test.ts
+++ b/test/print.test.ts
@@ -16,15 +16,12 @@ describe("print()", () => {
   });
   it("properly escapes strings", () => {
     expect(print(data.string("'hello'"))).toEqual(`"'hello'"`);
-    expect(print(data.string('"hello"'))).toEqual(`'"hello'`);
-    expect(print(data.string(`"'weird`))).toEqual(`"\\"'weird"\n`);
+    expect(print(data.string('"hello"'))).toEqual(`'"hello"'`);
+    expect(print(data.string(`"'weird`))).toEqual(`"\\"'weird"`);
   });
   it("prints lists", () => {
     expect(print(data.list([data.string("hello"), data.string("world")])))
-      .toEqual(`
-- hello
-- world
-`);
+      .toEqual(`- hello\n- world`);
   });
   it("prints maps", () => {
     expect(print(data.map({
@@ -48,13 +45,13 @@ describe("print()", () => {
   it("prints native functions", () => {
     expect(print(data.fn(function* id(cxt) {
       return cxt.arg;
-    }, { name: "x" }))).toEqual("(x)=>: [[native fn]]");
+    }, { name: "x" }))).toEqual("(x)=>: <[native fn]>");
   });
   it("prints function calls", () => {
-    expect(print(parse("$id: 5"))).toEqual("$id: 5")
+    expect(print(parse("$id: 5"))).toEqual("$id: 5");
   });
   it("prints external values", () => {
-    expect(print(data.external({}))).toEqual("[[external]]");
+    expect(print(data.external({}))).toEqual("<[external]>");
   });
   it("is the inverse of read by default", () => {
     expect(print(parse(`
@@ -65,6 +62,6 @@ plain: hi
 flow: {$read: hello world}
 block:
   $read: hello world
-`)))
+`)));
   });
 });

--- a/test/print.test.ts
+++ b/test/print.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "./suite.ts";
+import type { PSValue } from "../types.ts";
+
+import * as data from "../data.ts";
+import { print as $print, read } from "../mod.ts";
+import { recognize } from "../recognize.ts";
+
+const parse = (source: string) => recognize(read(source));
+const print = (val: PSValue) => $print(val).value;
+
+describe("print()", () => {
+  it("prints scalar values", () => {
+    expect(print(data.number(1))).toEqual("1");
+    expect(print(data.boolean(true))).toEqual("true");
+    expect(print(data.string("hello"))).toEqual("hello");
+  });
+  it("properly escapes strings", () => {
+    expect(print(data.string("'hello'"))).toEqual(`"'hello'"`);
+    expect(print(data.string('"hello"'))).toEqual(`'"hello'`);
+    expect(print(data.string(`"'weird`))).toEqual(`"\\"'weird"\n`);
+  });
+  it("prints lists", () => {
+    expect(print(data.list([data.string("hello"), data.string("world")])))
+      .toEqual(`
+- hello
+- world
+`);
+  });
+  it("prints maps", () => {
+    expect(print(data.map({
+      hello: data.string("world"),
+    }))).toEqual(`hello: world`);
+  });
+  it("prints references", () => {
+    expect(print(data.ref("x", ["y", "z"]))).toEqual("$x.y.z");
+  });
+  it("prints templates", () => {
+    expect(print(parse("hello %($world)"))).toEqual("hello %($world)");
+  });
+  it("prints platformscript functions", () => {
+    expect(print(parse("(x)=>: { message: hello world }"))).toEqual(
+      "(x)=>: { message: hello world }",
+    );
+    expect(print(parse("greet(person): { message: hello %(person) }"))).toEqual(
+      "greet(person): { message: hello %(person) }",
+    );
+  });
+  it("prints native functions", () => {
+    expect(print(data.fn(function* id(cxt) {
+      return cxt.arg;
+    }, { name: "x" }))).toEqual("(x)=>: [[native fn]]");
+  });
+  it("prints function calls", () => {
+    expect(print(parse("$id: 5"))).toEqual("$id: 5")
+  });
+  it("prints external values", () => {
+    expect(print(data.external({}))).toEqual("[[external]]");
+  });
+  it("is the inverse of read by default", () => {
+    expect(print(parse(`
+$import:
+  read, print: https://pls.pub/std.yaml
+quoted: "hi"
+plain: hi
+flow: {$read: hello world}
+block:
+  $read: hello world
+`)))
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -100,6 +100,7 @@ export interface PSFnCall {
   value: PSRef | PSFn;
   arg: PSValue;
   rest: PSMap;
+  source: PSMap;
 }
 
 export interface PSFnCallContext {


### PR DESCRIPTION
## Motivation

In order to print the results of an evaluation in PlatformScript (as opposed to JSON) we need a way to take _any_ PS value and convert it into a string. This is mandatory for things like:

- web based playground that renders output of an evaluation
- output the result of a program via `pls eval` or `pls run`
- rendering each iteration of a REPL.

## Approach

This introduces the `print()` function which is the inverse of the `read()` function. First we convert the PSValue _back_ into a YAML tree. Then, we use the native YAML serialization to produce the final string. 

While serializations are provided for "all" platform script values, the guiding principle is that if the value is a "literal" is from source, it will be printed exactly as it appeared in source. So, for example if the string appeared in source as a plain string `hello world` then it will be printed using a plain string. Whereas if it appeared as a single quoted string `'hello world'` then it will appear that way, even though functionally they are the same.
