### PR TITLE
fix version.json which was being written as YAML, not JSON

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -35,7 +35,7 @@ jobs:
           git config --global user.name "Frontside Jack"
           deno task rel:impact platformscript --pre=alpha | deno task changelog-entry $(deno task rel:next platformscript --pre=alpha) | cat - Changelog.md > Changelog.next.md
           mv Changelog.next.md Changelog.md
-          echo ${{ steps.versions.outputs.next }} > version.json
+          echo '"${{ steps.versions.outputs.next }}"' > version.json
           deno fmt
           git commit -am "prepare platformscript ${{ steps.versions.outputs.next }}"
 


### PR DESCRIPTION
## Motivation

In our version module, we are supposed to [write it as JSON](https://github.com/thefrontside/platformscript/pull/73/files) however, valid JSON requires double quotes for strings, not a bare word.

## Approach

This places double quotes around the version.

## Screenshots

Here you can see the error in `version.json` in the release pull request.

![image showing invalid version string lacking double quotes](https://user-images.githubusercontent.com/4205/217007798-7b8591f4-e2d6-44a0-b6dd-d87b584a37dc.png)
